### PR TITLE
[FIX] product variant sale price

### DIFF
--- a/product_variant_sale_price/models/product_product.py
+++ b/product_variant_sale_price/models/product_product.py
@@ -35,33 +35,19 @@ class ProductProduct(models.Model):
     def _compute_lst_price(self):
         for product in self:
             price = product.fix_price or product.list_price
-            if 'uom' in self.env.context:
-                uom = product.uos_id or product.uom_id
-                price = uom._compute_price(
-                    product.uom_id.id, price, self.env.context['uom'])
             product.lst_price = price
 
     @api.multi
     def _compute_list_price(self):
         for product in self:
             price = product.fix_price or product.product_tmpl_id.list_price
-            if 'uom' in self.env.context:
-                uom = product.uos_id or product.uom_id
-                price = uom._compute_price(
-                    product.uom_id.id, price, self.env.context['uom'])
             product.list_price = price
 
     @api.multi
     def _inverse_product_lst_price(self):
         for product in self:
             vals = {}
-            if 'uom' in self.env.context:
-                uom = product.uos_id or product.uom_id
-                vals['fix_price'] = uom._compute_price(
-                    product.uom_id.id, product.lst_price,
-                    self.env.context['uom'])
-            else:
-                vals['fix_price'] = product.lst_price
+            vals['fix_price'] = product.lst_price
             if product.product_variant_count == 1:
                 product.product_tmpl_id.list_price = vals['fix_price']
             else:


### PR DESCRIPTION
Fix the price for the variant.
When there is a conversion with different UOM, remove the conversion
here, as it's also called outside, and the conversion is duplicated.

Issue #54 
