### PR TITLE
[MIG] sale_variant_configurator: Migration to 10.0

### DIFF
--- a/sale_stock_variant_configurator/README.rst
+++ b/sale_stock_variant_configurator/README.rst
@@ -1,0 +1,47 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=============================
+Sale stock - Product variants
+=============================
+
+Glue module to preserve information on product template when sale_stock module
+is installed.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/137/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/product-variant/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_stock_variant_configurator/__init__.py
+++ b/sale_stock_variant_configurator/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/sale_stock_variant_configurator/__manifest__.py
+++ b/sale_stock_variant_configurator/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Sale - Product variants",
+    "summary": "Product variants in sale management",
+    "version": "10.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_variant_configurator",
+        "sale_stock",
+    ],
+    "author": "Tecnativa,"
+              "Odoo Community Association (OCA)",
+    "category": "Sales Management",
+    "website": "https://www.tecnativa.com",
+    "installable": True,
+    "auto_install": True,
+}

--- a/sale_stock_variant_configurator/models/__init__.py
+++ b/sale_stock_variant_configurator/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_order

--- a/sale_stock_variant_configurator/models/sale_order.py
+++ b/sale_stock_variant_configurator/models/sale_order.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    # Redefine again the product template field as a regular one
+    product_tmpl_id = fields.Many2one(
+        string='Product Template',
+        comodel_name='product.template',
+        store=True,
+        related=False,
+        auto_join=True,
+    )

--- a/sale_variant_configurator/README.rst
+++ b/sale_variant_configurator/README.rst
@@ -1,0 +1,36 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Sale - Product variants
+=======================
+
+This module allows you to create the product variant when a sale order is
+confirmed. It adds to the sale line a product configurator, so that selecting
+a product and its attributes can serve for creating/selecting the product
+variant.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/188/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/product-variant/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Ana Juaristi <ajuaristio@gmail.com>

--- a/sale_variant_configurator/README.rst
+++ b/sale_variant_configurator/README.rst
@@ -16,15 +16,15 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/137/9.0
+   :target: https://runbot.odoo-community.org/runbot/137/10.0
 
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/product-variant/issues>`_.
-In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and
-welcomed feedback.
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/product-variant/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======
@@ -34,3 +34,19 @@ Contributors
 * Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Ana Juaristi <ajuaristio@gmail.com>
+* David Vidal <david.vidal@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_variant_configurator/README.rst
+++ b/sale_variant_configurator/README.rst
@@ -16,7 +16,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/188/9.0
+   :target: https://runbot.odoo-community.org/runbot/137/9.0
 
 Bug Tracker
 ===========

--- a/sale_variant_configurator/__init__.py
+++ b/sale_variant_configurator/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models
+from .hooks import assign_product_template

--- a/sale_variant_configurator/__manifest__.py
+++ b/sale_variant_configurator/__manifest__.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-# © 2014-2016 Oihane Crucelaegui - AvanzOSC
-# © 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2014-2016 Oihane Crucelaegui - AvanzOSC
+# Copyright 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2017 David Vidal <david.vidal@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
     "name": "Sale - Product variants",
     "summary": "Product variants in sale management",
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "license": "AGPL-3",
     "depends": [
         "sale",

--- a/sale_variant_configurator/__openerp__.py
+++ b/sale_variant_configurator/__openerp__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# © 2014-2016 Oihane Crucelaegui - AvanzOSC
+# © 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Sale - Product variants",
+    "summary": "Product variants in sale management",
+    "version": "9.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": [
+        "sale",
+        "product_variant_configurator",
+    ],
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Tecnativa,"
+              "Odoo Community Association (OCA)",
+    "category": "Sales Management",
+    "website": "http://www.odoomrp.com",
+    "data": [
+        "views/sale_view.xml",
+    ],
+    "installable": True,
+    "post_init_hook": "assign_product_template",
+}

--- a/sale_variant_configurator/hooks.py
+++ b/sale_variant_configurator/hooks.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# © 2014-2016 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+
+def assign_product_template(cr, registry):
+    """This post-init-hook will update all existing sale.order.line"""
+    cr.execute("""
+        UPDATE sale_order_line AS line
+        SET product_tmpl_id = product_product.product_tmpl_id
+        FROM product_product
+        WHERE line.product_id = product_product.id;""")

--- a/sale_variant_configurator/models/__init__.py
+++ b/sale_variant_configurator/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import sale_order

--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -56,7 +56,7 @@ class SaleOrder(models.Model):
                     'attribute_value_ids': [(6, 0, values.ids)],
                 })
             line.write({'product_id': product.id})
-        super(SaleOrderLine, self).action_confirm()
+        super(SaleOrder, self).action_confirm()
 
 
 class SaleOrderLine(models.Model):
@@ -116,7 +116,8 @@ class SaleOrderLine(models.Model):
     def _auto_init(self, cr, context=None):
         # Avoid the removal of the DB column due to sale_stock defining
         # this field as a related non stored one
-        if self._columns.get('product_tmpl_id'):
-            self._columns['product_tmpl_id'].store = True
-            self._columns['product_tmpl_id'].readonly = False
+        if self._fields.get('product_tmpl_id'):
+            self._fields['product_tmpl_id'].store = True
+            self._fields['product_tmpl_id'].readonly = False
+            self._fields['product_tmpl_id'].related = False
         super(SaleOrderLine, self)._auto_init(cr, context=context)

--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+# © 2014-2016 Oihane Crucelaegui - AvanzOSC
+# © 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, fields, models
+from lxml import etree
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.model
+    def fields_view_get(self, view_id=None, view_type='form', toolbar=False,
+                        submenu=False):
+        """Avoid to have 2 times the field product_tmpl_id, as modules like
+        sale_stock adds this field as invisible, so we can't trust the order
+        of them. We also override the modifiers to avoid a readonly field.
+        """
+        res = super(SaleOrder, self).fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar,
+            submenu=submenu)
+        if view_type != 'form':
+            return res  # pragma: no cover
+        if 'order_line' not in res['fields']:
+            return res  # pragma: no cover
+        line_field = res['fields']['order_line']
+        if 'form' not in line_field['views']:
+            return res  # pragma: no cover
+        view = line_field['views']['form']
+        eview = etree.fromstring(view['arch'])
+        fields = eview.xpath("//field[@name='product_tmpl_id']")
+        field_added = False
+        for field in fields:
+            if field.get('invisible') or field_added:
+                field.getparent().remove(field)
+            else:
+                # Remove modifiers that makes the field readonly
+                field.set('modifiers', "")
+                field_added = True
+        view['arch'] = etree.tostring(eview)
+        return res
+
+    @api.multi
+    def action_confirm(self):
+        product_obj = self.env['product.product']
+        lines = self.mapped('order_line').filtered(lambda x: not x.product_id)
+        for line in lines:
+            product = product_obj._product_find(
+                line.product_tmpl_id, line.product_attribute_ids,
+            )
+            if not product:
+                values = line.product_attribute_ids.mapped('value_id')
+                product = product_obj.create({
+                    'product_tmpl_id': line.product_tmpl_id.id,
+                    'attribute_value_ids': [(6, 0, values.ids)],
+                })
+            line.write({'product_id': product.id})
+        super(SaleOrderLine, self).action_confirm()
+
+
+class SaleOrderLine(models.Model):
+    _inherit = ["sale.order.line", "product.configurator"]
+    _name = "sale.order.line"
+
+    product_id = fields.Many2one(required=False)
+
+    @api.onchange('product_tmpl_id')
+    def _onchange_product_tmpl_id_configurator(self):
+        obj = super(SaleOrderLine, self)
+        res = obj._onchange_product_tmpl_id_configurator()
+        if self.product_tmpl_id.attribute_line_ids:
+            domain = res.setdefault('domain', {})
+            domain['product_uom'] = [
+                ('category_id', '=',
+                 self.product_tmpl_id.uom_id.category_id.id),
+            ]
+            self.product_uom = self.product_tmpl_id.uom_id
+            self.price_unit = self.order_id.pricelist_id.with_context(
+                {'uom': self.product_uom.id,
+                 'date': self.order_id.date_order}).template_price_get(
+                self.product_tmpl_id.id, self.product_uom_qty or 1.0,
+                self.order_id.partner_id.id)[self.order_id.pricelist_id.id]
+        # Update taxes
+        fpos = (self.order_id.fiscal_position_id or
+                self.order_id.partner_id.property_account_position_id)
+        # If company_id is set, always filter taxes by the company
+        taxes = self.product_tmpl_id.taxes_id.filtered(
+            lambda r: not self.company_id or r.company_id == self.company_id
+        )
+        self.tax_id = fpos.map_tax(taxes) if fpos else taxes
+        product_tmpl = self.product_tmpl_id.with_context(
+            lang=self.order_id.partner_id.lang,
+            partner=self.order_id.partner_id.id,
+            quantity=self.product_uom_qty,
+            date=self.order_id.date_order,
+            pricelist=self.order_id.pricelist_id.id,
+            uom=self.product_uom.id,
+        )
+        # TODO: Check why this is reset
+        if product_tmpl.description_sale:
+            self.name = (
+                (self.name or '') + '\n' + product_tmpl.description_sale
+            )
+        if self.order_id.pricelist_id and self.order_id.partner_id:
+            self.price_unit = self.env['account.tax']._fix_tax_included_price(
+                product_tmpl.price, product_tmpl.taxes_id, self.tax_id,
+            )
+        return res
+
+    @api.onchange('product_uom', 'product_uom_qty')
+    def product_uom_change(self):
+        # TODO: Handle this when there's no product_id filled
+        super(SaleOrderLine, self).product_uom_change()
+
+    def _auto_init(self, cr, context=None):
+        # Avoid the removal of the DB column due to sale_stock defining
+        # this field as a related non stored one
+        if self._columns.get('product_tmpl_id'):
+            self._columns['product_tmpl_id'].store = True
+            self._columns['product_tmpl_id'].readonly = False
+        super(SaleOrderLine, self)._auto_init(cr, context=context)

--- a/sale_variant_configurator/tests/__init__.py
+++ b/sale_variant_configurator/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_sale_order

--- a/sale_variant_configurator/tests/test_sale_order.py
+++ b/sale_variant_configurator/tests/test_sale_order.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 David Vidal
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests import common
+
+
+class TestSaleOrder(common.SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSaleOrder, cls).setUpClass()
+        # Environments
+        cls.product_attribute = cls.env['product.attribute']
+        cls.product_attribute_value = cls.env['product.attribute.value']
+        cls.product_template = cls.env['product.template'].with_context(
+            check_variant_creation=True)
+        cls.sale_order = cls.env['sale.order']
+        cls.product_product = cls.env['product.product']
+        cls.sale_order_line = cls.env['sale.order.line']
+        cls.res_partner = cls.env['res.partner']
+        cls.product_category = cls.env['product.category']
+        # Instances
+        cls.category1 = cls.product_category.create({
+            'name': 'No create variants category',
+        })
+        cls.attribute1 = cls.product_attribute.create({
+            'name': 'Color',
+        })
+        cls.value1 = cls.product_attribute_value.create({
+            'name': 'Red',
+            'attribute_id': cls.attribute1.id,
+        })
+        cls.value2 = cls.product_attribute_value.create({
+            'name': 'Green',
+            'attribute_id': cls.attribute1.id,
+        })
+        cls.product_template_yes = cls.product_template.create({
+            'name': 'Product template 1',
+            'list_price': 100,
+            'no_create_variants': 'yes',
+            'categ_id': cls.category1.id,
+            'attribute_line_ids': [
+                (0, 0, {'attribute_id': cls.attribute1.id,
+                        'value_ids': [(6, 0, [cls.value1.id,
+                                              cls.value2.id])]})],
+        })
+        cls.product_template_no = cls.product_template.create({
+            'name': 'Product template 2',
+            'list_price': 100,
+            'categ_id': cls.category1.id,
+            'no_create_variants': 'no',
+            'description_sale': 'Template description'
+        })
+        cls.attribute_price1 = cls.env['product.attribute.price'].create({
+            'product_tmpl_id': cls.product_template_yes.id,
+            'attribute_id': cls.attribute1.id,
+            'value_id': cls.value1.id,
+            'price_extra': 10,
+        })
+        cls.customer = cls.res_partner.create({
+            'name': 'Customer 1',
+        })
+
+    def test_onchange_product_tmpl_id(self):
+        sale = self.sale_order.create({'partner_id': self.customer.id})
+        line1 = self.sale_order_line.new({
+            'order_id': sale.id,
+            'product_tmpl_id': self.product_template_yes.id,
+            'price_unit': 100,
+            'product_uom': self.product_template_yes.uom_id.id,
+            'product_qty': 1,
+        })
+        result = line1._onchange_product_tmpl_id_configurator()
+        self.assertEqual(len(line1.product_attribute_ids), 1)
+        expected_domain = [
+            ('product_tmpl_id', '=', self.product_template_yes.id)
+        ]
+        self.assertEqual(result['domain']['product_id'], expected_domain)
+        line2 = self.sale_order_line.new({
+            'order_id': sale.id,
+            'product_tmpl_id': self.product_template_no.id,
+            'product_uom': self.product_template_no.uom_id.id,
+            'product_qty': 1,
+            'price_unit': 200,
+            'name': 'Line 2',
+        })
+        line2._onchange_product_tmpl_id_configurator()
+        line2._onchange_product_id_configurator()
+        line2.product_id_change()
+        self.assertEqual(line2.product_id,
+                         self.product_template_no.product_variant_ids)
+        self.assertEqual(line2.name,
+                         '%s\n%s' % (
+                             self.product_template_no.name,
+                             (self.product_template_no.description_sale)
+                         ))
+
+    def test_onchange_product_attribute_ids(self):
+        sale = self.sale_order.create({'partner_id': self.customer.id})
+        line = self.sale_order_line.new({
+            'order_id': sale.id,
+            'product_tmpl_id': self.product_template_yes.id,
+            'price_unit': 0,
+            'name': 'Line 1',
+            'product_qty': 1,
+            'product_uom': self.product_template_yes.uom_id.id,
+        })
+        line._onchange_product_tmpl_id_configurator()
+        self.assertEqual(line.price_unit, 100)  # List price
+        line.product_attribute_ids[0].value_id = self.value1.id
+        result = line._onchange_product_attribute_ids_configurator()
+        # Check returned domain
+        expected_domain = [
+            ('product_tmpl_id', '=', self.product_template_yes.id),
+            ('attribute_value_ids', '=', self.value1.id)
+        ]
+        self.assertDictEqual(result['domain'], {'product_id': expected_domain})
+        # Check price brought to line with extra
+        self.assertEqual(line.price_unit, 110)
+        # Create product and onchange again to see if the product is selected
+        product = self.product_product.create({
+            'product_tmpl_id': self.product_template_yes.id,
+            'product_attribute_ids': [(0, 0, {
+                'product_tmpl_id': self.product_template_yes.id,
+                'attribute_id': self.attribute1.id,
+                'value_id': self.value1.id,
+                'owner_model': 'sale.order.line',
+            })]
+        })
+        line._onchange_product_attribute_ids_configurator()
+        self.assertEqual(line.product_id, product)
+
+    def test_can_create_product_variant(self):
+        sale = self.sale_order.create({'partner_id': self.customer.id})
+        line = self.sale_order_line.new({
+            'order_id': sale.id,
+            'product_tmpl_id': self.product_template_yes.id,
+            'price_unit': 100,
+            'name': 'Line 1',
+            'product_qty': 1,
+            'product_uom': self.product_template_yes.uom_id.id,
+        })
+        self.assertFalse(line.can_create_product)
+        attributes = self.env['product.configurator.attribute'].create({
+            'product_tmpl_id': self.product_template_yes.id,
+            'attribute_id': self.attribute1.id,
+            'value_id': self.value1.id,
+            'owner_model': 'sale.order.line',
+            'owner_id': line.id,
+        })
+        line.product_attribute_ids = attributes
+        line._onchange_product_attribute_ids_configurator()
+        self.assertTrue(line.can_create_product)
+        line.create_product_variant = True
+        line._onchange_create_product_variant()
+        self.assertTrue(line.product_id)
+        self.assertFalse(line.create_product_variant)
+
+    def test_onchange_product_id(self):
+        product = self.product_product.create({
+            'product_tmpl_id': self.product_template_yes.id,
+            'product_attribute_ids': [(0, 0, {
+                'product_tmpl_id': self.product_template_yes.id,
+                'attribute_id': self.attribute1.id,
+                'value_id': self.value1.id
+            })]
+        })
+        order = self.sale_order.create({
+            'partner_id': self.customer.id,
+            'order_line': [(0, 0, {
+                'product_id': product.id,
+                'price_unit': 100,
+                'name': 'Line 1',
+                'product_qty': 1,
+                'product_uom': product.uom_id.id,
+            })]
+        })
+        line = order.order_line[0]
+        with self.cr.savepoint():
+            line.product_id_change()
+            line._onchange_product_id_configurator()
+            self.assertEqual(len(line.product_attribute_ids), 1)
+            self.assertEqual(line.product_tmpl_id, self.product_template_yes)
+
+    def test_action_confirm(self):
+        order = self.sale_order.create({'partner_id': self.customer.id})
+        line_1 = self.sale_order_line.new({
+            'order_id': order.id,
+            'product_tmpl_id': self.product_template_yes.id,
+            'price_unit': 100,
+            'name': 'Line 1',
+            'product_qty': 1,
+            'product_uom': self.product_template_yes.uom_id.id,
+            'product_attribute_ids': [(0, 0, {
+                'product_tmpl_id': self.product_template_yes.id,
+                'attribute_id': self.attribute1.id,
+                'value_id': self.value1.id,
+                'owner_model': 'sale.order.line'
+            })],
+            'create_product_variant': True,
+        })
+        line_2 = self.sale_order_line.new({
+            'order_id': order.id,
+            'product_tmpl_id': self.product_template_no.id,
+            'product_uom': self.product_template_no.uom_id.id,
+            'product_qty': 1,
+            'price_unit': 200,
+            'name': 'Line 2',
+            'create_product_variant': True,
+        })
+        for line in (line_1, line_2):
+            line._onchange_product_tmpl_id_configurator()
+            line._onchange_product_id_configurator()
+            line.product_id_change()
+            line._onchange_product_attribute_ids_configurator()
+            if line.can_create_product:
+                line.create_variant_if_needed()
+                line.create_product_variant = True
+                line._onchange_create_product_variant()
+        order.write({'order_line': [(4, line_1.id), (4, line_2.id)]})
+        order.action_confirm()
+        order_line_without_product = order.order_line.filtered(
+            lambda x: not x.product_id)
+        self.assertEqual(len(order_line_without_product), 0,
+                         "All purchase lines must have a product")

--- a/sale_variant_configurator/views/sale_view.xml
+++ b/sale_variant_configurator/views/sale_view.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_order_form">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="priority" eval="20" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/tree" position="attributes">
+                <attribute name="editable"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='product_id']"
+                   position="before">
+                <field name="product_tmpl_id" />
+            </xpath>
+            <xpath expr="//field[@name='order_line']" position="attributes">
+                <attribute name="options">{'reload_on_button': true}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/form//field[@name='product_id']"
+                   position="before">
+                <field name="product_tmpl_id" />
+                <field name="product_attribute_ids"
+                       context="{'default_owner_model': 'sale.order.line', 'default_owner_id': id}"
+                       attrs="{'invisible':[('product_attribute_ids','=',[])]}">
+                    <!-- We are not using isolated view because onchange doesn't work in this case -->
+                    <tree create="0" delete="0" editable="1">
+                        <field name="owner_model" invisible="1"/>
+                        <field name="owner_id" invisible="1"/>
+                        <field name="attribute_id" />
+                        <field name="possible_value_ids" widget="many2many_tags" invisible="1"/>
+                        <field name="product_tmpl_id" invisible="1"/>
+                        <field name="value_id"/>
+                        <field name="price_extra"/>
+                    </tree>
+                </field>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_order_line_tree">
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="sale.view_order_line_tree" />
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="product_tmpl_id" />
+                <field name="product_id" />
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_sales_order_line_filter">
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="sale.view_sales_order_line_filter" />
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="product_tmpl_id" />
+            </field>
+            <filter context="{'group_by':'product_id'}" position="after">
+                <filter string="Template" name="search_template"
+                        domain="[]"
+                        context="{'group_by':'product_tmpl_id'}" />
+            </filter>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Sale - Product variants
=======================

This module allows you to create the product variant when a sale order is
confirmed. It adds to the sale line a product configurator, so that selecting
a product and its attributes can serve for creating/selecting the product
variant.

Depends on:

- [x] product_variant_configurator: https://github.com/OCA/product-variant/pull/65

cc @Tecnativa