### PR TITLE
[FIX] product_variant_sale_price: avoid to update list price of all variants

### DIFF
--- a/product_variant_sale_price/models/product_product.py
+++ b/product_variant_sale_price/models/product_product.py
@@ -23,7 +23,8 @@ class ProductTemplate(models.Model):
     def write(self, vals):
         res = super(ProductTemplate, self).write(vals)
         for template in self:
-            template._update_fix_price(vals)
+            if not self.env.context.get('skip_update_fix_price', False):
+                template._update_fix_price(vals)
         return res
 
 
@@ -68,7 +69,8 @@ class ProductProduct(models.Model):
                 fix_prices = product.product_tmpl_id.mapped(
                     'product_variant_ids.fix_price')
                 # for consistency with price shown in the shop
-                product.product_tmpl_id.list_price = min(fix_prices)
+                product.product_tmpl_id.with_context(
+                    skip_update_fix_price=True).list_price = min(fix_prices)
             product.write(vals)
 
     lst_price = fields.Float(

--- a/product_variant_sale_price/tests/test_product_product.py
+++ b/product_variant_sale_price/tests/test_product_product.py
@@ -89,6 +89,11 @@ class TestProductVariantPrice(TransactionCase):
             self.product_blue.product_tmpl_id.list_price)
         self.assertEqual(
             self.product_blue.lst_price, self.product_blue.fix_price)
+        # to check skip_update_fix_price
+        self.assertNotEqual(
+            self.product_blue.lst_price,
+            self.product_red.lst_price)
+        self.assertEqual(self.product_red.lst_price, 1500.00)
 
     def test_update_template_variant(self):
         self.product_blue.product_tmpl_id.list_price = 200


### PR DESCRIPTION
Steps to reproduce:
- create more than one variant
- change `fix_price` of one variant

Current behavior:
- `lst_price` of all variants are changed

Expected behavior:
- `lst_price` of only selected variant is changed