### PR TITLE
[FIX] product_variant_sale_price: writting template list_price should not write its variants

### DIFF
--- a/product_variant_sale_price/models/product_product.py
+++ b/product_variant_sale_price/models/product_product.py
@@ -64,11 +64,6 @@ class ProductProduct(models.Model):
                 vals['fix_price'] = product.lst_price
             if product.product_variant_count == 1:
                 product.product_tmpl_id.list_price = vals['fix_price']
-            else:
-                fix_prices = product.product_tmpl_id.mapped(
-                    'product_variant_ids.fix_price')
-                # for consistency with price shown in the shop
-                product.product_tmpl_id.list_price = min(fix_prices)
             product.write(vals)
 
     lst_price = fields.Float(


### PR DESCRIPTION
related to bug introduced by 4a7511f via #37

Related to: https://github.com/OCA/product-variant/pull/80#issuecomment-338980134

cc @pedrobaeza @sergio-teruel @tafaRU @anajuaristi 