### PR TITLE
[9.0][FIX]product_variant_configurator: fix create_variant_ids

### DIFF
--- a/product_variant_configurator/models/product_template.py
+++ b/product_variant_configurator/models/product_template.py
@@ -28,11 +28,13 @@ class ProductTemplate(models.Model):
             # avoid the warning when opening a new form in create
             # mode (ie when the onchange triggers when Odoo sets
             # the default value)
+            msg = _("Changing this parameter may cause automatic variants "
+                    "creation (in case variants are created automatically),"
+                    "or automatic variants deactivation (in case variants "
+                    "are created manually).")
             return {'warning':
                     {'title': _('Change warning!'),
-                     'message': _('Changing this parameter may cause'
-                                  ' automatic variants creation')}
-                    }
+                     'message': msg}}
 
     @api.model
     def create(self, vals):

--- a/product_variant_configurator/models/product_template.py
+++ b/product_variant_configurator/models/product_template.py
@@ -22,8 +22,7 @@ class ProductTemplate(models.Model):
 
     @api.onchange('no_create_variants')
     def onchange_no_create_variants(self):
-        if self.no_create_variants in ['no', 'empty'] and \
-                self._origin.no_create_variants:
+        if self._origin.no_create_variants:
             # the test on self._origin.no_create_variants is to
             # avoid the warning when opening a new form in create
             # mode (ie when the onchange triggers when Odoo sets

--- a/product_variant_configurator/models/product_template.py
+++ b/product_variant_configurator/models/product_template.py
@@ -64,6 +64,20 @@ class ProductTemplate(models.Model):
                     tmpl.no_create_variants == 'no' or
                     not tmpl.attribute_line_ids):
                 super(ProductTemplate, tmpl).create_variant_ids()
+                continue
+            if tmpl.attribute_line_ids and (
+                tmpl.no_create_variants == 'yes' or
+                (tmpl.no_create_variants == 'empty' and
+                 tmpl.categ_id.no_create_variants)):
+                variants_without_attribute = tmpl.product_variant_ids.filtered(
+                    lambda p: not p.attribute_value_ids)
+                if not variants_without_attribute:
+                    continue
+                # We can't unlink bc in the standard, if the we delete a
+                # variant and that variant is the only one exists
+                # (or it is the last one), the product template will be
+                # deleted as well.
+                variants_without_attribute.write({'active': False})
         return True
 
     @api.multi


### PR DESCRIPTION
In standard, when attributes are added to an already created product
template, the variant without attributes is deleted or deactivated (been
used somewhere else) automatically.
In product variant configurator module we loosing that behavior when the
creation of the variants are delayed (i.e case where no auto variants are created).
This PR aims to restore that behavior by deactivating the variant with
no attributes.