### PR TITLE
[10.0] product_variant_default_code : empty separator + codes ordering

### DIFF
--- a/product_variant_default_code/README.rst
+++ b/product_variant_default_code/README.rst
@@ -80,6 +80,11 @@ Unset `manual code` and the reference code will be unlocked again.
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/137/10.0
 
+Change the reference separator
+------------------------------
+
+You can change the separator using the system parameter named "default_reference_separator".
+If you do not want to have a separator (an empty one), you can the the parameter to "None".
 
 Known issues / Roadmap
 ======================

--- a/product_variant_default_code/README.rst
+++ b/product_variant_default_code/README.rst
@@ -76,15 +76,15 @@ variant internal reference will no longer be changed by this module.
 
 Unset `manual code` and the reference code will be unlocked again.
 
-.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
-   :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/137/10.0
-
 Change the reference separator
 ------------------------------
 
 You can change the separator using the system parameter named "default_reference_separator".
-If you do not want to have a separator (an empty one), you can the the parameter to "None".
+If you do not want to have a separator (an empty one), you can set the parameter to "None".
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/137/10.0
 
 Known issues / Roadmap
 ======================

--- a/product_variant_default_code/__manifest__.py
+++ b/product_variant_default_code/__manifest__.py
@@ -7,7 +7,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Product Variant Default Code',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'author': 'AvancOSC,'
               'Shine IT,'
               'Tecnativa,'

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -103,7 +103,7 @@ class ProductTemplate(models.Model):
 
     def _get_default_mask(self):
         if not self.attribute_line_ids:
-            return None
+            return False
         attribute_names = []
         default_reference_separator = self.env[
             'ir.config_parameter'].get_param('default_reference_separator')
@@ -191,7 +191,6 @@ class ProductAttribute(models.Model):
 
     def write(self, vals):
         result = super(ProductAttribute, self).write(vals)
-
         if 'code' not in vals:
             return result
         # Rewrite reference on all product variants affected

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -98,11 +98,17 @@ class ProductTemplate(models.Model):
              '\nNote: make sure characters "[,]" do not appear in your '
              'attribute name')
 
+    def _get_attr_val_k(self, attr_value_id):
+        return attr_value_id.attribute_id.sequence
+
     def _get_default_mask(self):
         attribute_names = []
         default_reference_separator = self.env[
             'ir.config_parameter'].get_param('default_reference_separator')
-        for line in self.attribute_line_ids:
+        # impossible to have an empty ir_config_parameter
+        if default_reference_separator == 'None':
+            default_reference_separator = ''
+        for line in sorted(self.attribute_line_ids, key=self._get_attr_val_k):
             attribute_names.append(u"[{}]".format(line.attribute_id.name))
         default_mask = ((self.code_prefix or '') +
                         default_reference_separator.join(attribute_names))

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -102,6 +102,8 @@ class ProductTemplate(models.Model):
         return attr_value_id.attribute_id.sequence
 
     def _get_default_mask(self):
+        if not self.attribute_line_ids:
+            return None
         attribute_names = []
         default_reference_separator = self.env[
             'ir.config_parameter'].get_param('default_reference_separator')
@@ -114,34 +116,36 @@ class ProductTemplate(models.Model):
                         default_reference_separator.join(attribute_names))
         return default_mask
 
+    def _is_automatic_mask(self):
+        return not self.user_has_groups(
+            'product_variant_default_code'
+            '.group_product_default_code')
+
     @api.model
     def create(self, vals):
         product = self.new(vals)
-        if (not vals.get('reference_mask') and product.attribute_line_ids or
-                not self.user_has_groups(
-                    'product_variant_default_code.group_product_default_code'
-                )):
+        if self._is_automatic_mask() or not vals.get('reference_mask'):
             vals['reference_mask'] = product._get_default_mask()
-        elif vals.get('reference_mask'):
+        else:
             sanitize_reference_mask(product, vals['reference_mask'])
         return super(ProductTemplate, self).create(vals)
 
+    def _mask_needs_update(self, vals):
+        return 'code_prefix' in vals or 'attribute_line_ids' in vals
+
     def write(self, vals):
-        product_obj = self.env['product.product']
-        if ('reference_mask' in vals and not vals['reference_mask'] or not
-                self.user_has_groups(
-                    'product_variant_default_code.group_product_default_code'
-                )):
-            if self.attribute_line_ids:
-                vals['reference_mask'] = self._get_default_mask()
         result = super(ProductTemplate, self).write(vals)
+        if (self._is_automatic_mask() and self._mask_needs_update(vals)) \
+                or ('reference_mask' in vals and not vals['reference_mask']):
+            for record in self:
+                # we write the new mask and the additional write
+                # will recompute the variant code
+                record.reference_mask = record._get_default_mask()
         if vals.get('reference_mask'):
-            cond = [('product_tmpl_id', '=', self.id),
+            cond = [('product_tmpl_id', 'in', self.ids),
                     ('manual_code', '=', False)]
-            products = product_obj.search(cond)
-            for product in products:
-                if product.reference_mask:
-                    render_default_code(product, product.reference_mask)
+            for product in self.env['product.product'].search(cond):
+                render_default_code(product, product.reference_mask)
         return result
 
     @api.model
@@ -186,9 +190,10 @@ class ProductAttribute(models.Model):
         ('number_uniq', 'unique(name)', _('Attribute Name must be unique!'))]
 
     def write(self, vals):
-        if 'code' not in vals:
-            return super(ProductAttribute, self).write(vals)
         result = super(ProductAttribute, self).write(vals)
+
+        if 'code' not in vals:
+            return result
         # Rewrite reference on all product variants affected
         for product in self.mapped('attribute_line_ids').mapped(
             'product_tmpl_id').mapped('product_variant_ids').filtered(
@@ -219,9 +224,9 @@ class ProductAttributeValue(models.Model):
         return super(ProductAttributeValue, self).create(vals)
 
     def write(self, vals):
-        if 'code' not in vals:
-            return super(ProductAttributeValue, self).write(vals)
         result = super(ProductAttributeValue, self).write(vals)
+        if 'code' not in vals:
+            return result
         # Rewrite reference on all product variants affected
         for product in self.mapped('product_ids').filtered(
                 lambda x: x.product_tmpl_id.reference_mask and not

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -76,8 +76,9 @@ class TestVariantDefaultCode(common.SavepointCase):
             self.assertEqual(product.default_code, expected_code)
 
     def test_03_reset_reference_mask_to_default(self):
+        self.env.user.groups_id |= self.group_default_code
         # Erase the previous mask: 'P01/[TSize][TColor]'
-        self.template2.reference_mask = ''
+        self.template2.write({'reference_mask': ''})
         # Mask is set to default now:
         self.assertEqual(self.template2.reference_mask, '[TSize]-[TColor]')
 
@@ -157,10 +158,9 @@ class TestVariantDefaultCode(common.SavepointCase):
             '^_^' in self.template1.product_variant_ids[0].default_code)
 
     def test_11_check_none_separator(self):
-        self.env['ir.config_parameter'].write({
-            'key': 'default_reference_separator',
-            'value': 'None'
-        })
+        self.env.user.groups_id |= self.group_default_code
+        self.env['ir.config_parameter'].set_param(
+            'default_reference_separator', 'None')
         # re-initialize reference mask
-        self.template2.reference_mask = ''
+        self.template2.write({'reference_mask': ''})
         self.assertEqual(self.template2.reference_mask, '[TSize][TColor]')

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -51,6 +51,15 @@ class TestVariantDefaultCode(common.SavepointCase):
             ],
             'reference_mask': 'P01/[TSize][TColor]',
         })
+        # Only one attribute
+        cls.template3 = cls.env['product.template'].create({
+            'name': 'Socks',
+            'attribute_line_ids': [
+                (0, 0, {'attribute_id': cls.attr1.id,
+                        'value_ids': [(6, 0, [cls.attr1_1.id, cls.attr1_2.id])]
+                        })
+            ]
+        })
 
     def test_01_check_default_codes(self):
         # As no mask was set, a default one should be:
@@ -175,3 +184,15 @@ class TestVariantDefaultCode(common.SavepointCase):
         templates.write({'list_price': 4})
         for template in templates:
             self.assertEqual(template.list_price, 4)
+
+    def test_14_check_attribute_lines_modification(self):
+        self.assertEqual(self.template3.reference_mask, '[TSize]')
+        self.template3.write({
+            'attribute_line_ids': [
+                (0, 0, {'attribute_id': self.attr2.id,
+                        'value_ids': [
+                            (6, 0, [self.attr2_1.id, self.attr2_2.id])]
+                        }),
+            ]
+        })
+        self.assertEqual(self.template3.reference_mask, '[TSize]-[TColor]')

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -79,7 +79,7 @@ class TestVariantDefaultCode(common.SavepointCase):
         # Erase the previous mask: 'P01/[TSize][TColor]'
         self.template2.reference_mask = ''
         # Mask is set to default now:
-        self.assertEqual(self.template1.reference_mask, '[TSize]-[TColor]')
+        self.assertEqual(self.template2.reference_mask, '[TSize]-[TColor]')
 
     def test_04_custom_reference_mask(self):
         self.env.user.groups_id |= self.group_default_code
@@ -155,3 +155,12 @@ class TestVariantDefaultCode(common.SavepointCase):
         self.attr1_1.code = '^_^'
         self.assertTrue(
             '^_^' in self.template1.product_variant_ids[0].default_code)
+
+    def test_11_check_none_separator(self):
+        self.env['ir.config_parameter'].write({
+            'key': 'default_reference_separator',
+            'value': 'None'
+        })
+        # re-initialize reference mask
+        self.template2.reference_mask = ''
+        self.assertEqual(self.template2.reference_mask, '[TSize][TColor]')

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -164,3 +164,14 @@ class TestVariantDefaultCode(common.SavepointCase):
         # re-initialize reference mask
         self.template2.write({'reference_mask': ''})
         self.assertEqual(self.template2.reference_mask, '[TSize][TColor]')
+
+    def test_12_check_code_prefix_modification(self):
+        # Automatic mode
+        self.template1.write({'code_prefix': 'AA'})
+        self.assertEqual(self.template1.reference_mask, 'AA[TSize]-[TColor]')
+
+    def test_13_write_on_multiple_record(self):
+        templates = self.template1 | self.template2
+        templates.write({'list_price': 4})
+        for template in templates:
+            self.assertEqual(template.list_price, 4)


### PR DESCRIPTION
This PR allows to use an empty separator by using the "None" string in the system parameter. It is impossible to set a system parameter to an empty string so if we need to use an empty separator we can use "None" as a string.

Moreover it forces the sorting order on the attribute sequence. It is possible to easily overwrite it because the _get_attr_val_k function is one line long.