### PR TITLE
[10.0] product_variant_default_code: add code_prefix to the template's default_code

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -188,7 +188,11 @@ class ProductProduct(models.Model):
 
     @api.onchange('default_code')
     def onchange_default_code(self):
-        self.manual_code = bool(self.default_code)
+        for product in self:
+            # it shouldn't be possible to be in 'manual_code' mode
+            # when there is only 1 variant
+            if product.product_variant_count > 1:
+                self.manual_code = bool(self.default_code)
 
 
 class ProductAttribute(models.Model):

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -98,7 +98,11 @@ class ProductTemplate(models.Model):
              '\nNote: make sure characters "[,]" do not appear in your '
              'attribute name')
 
-    @api.depends('product_variant_ids', 'product_variant_ids.default_code')
+    @api.depends(
+        'product_variant_ids',
+        'product_variant_ids.default_code',
+        'code_prefix',
+        )
     def _compute_default_code(self):
         super(ProductTemplate, self)._compute_default_code()
         unique_variants = self.filtered(

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -38,31 +38,6 @@ def sanitize_reference_mask(product, mask):
                           'Reference Mask"'))
 
 
-def get_rendered_default_code(product, mask):
-    product_attrs = defaultdict(str)
-    reference_mask = ReferenceMask(mask)
-    main_lang = product.product_tmpl_id._guess_main_lang()
-    for value in product.attribute_value_ids:
-        attr_name = value.attribute_id.with_context(lang=main_lang).name
-        if value.attribute_id.code:
-            product_attrs[attr_name] += value.attribute_id.code
-        if value.code:
-            product_attrs[attr_name] += value.code
-    all_attrs = extract_token(mask)
-    missing_attrs = all_attrs - set(product_attrs.keys())
-    missing = dict.fromkeys(
-        missing_attrs,
-        product.env['ir.config_parameter'].get_param(
-            'default_reference_missing_placeholder'))
-    product_attrs.update(missing)
-    default_code = reference_mask.safe_substitute(product_attrs)
-    return default_code
-
-
-def render_default_code(product, mask):
-    product.default_code = get_rendered_default_code(product, mask)
-
-
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
@@ -105,9 +80,9 @@ class ProductTemplate(models.Model):
         )
     def _compute_default_code(self):
         super(ProductTemplate, self)._compute_default_code()
-        unique_variants = self.filtered(
-            lambda template: len(template.product_variant_ids) == 1)
-        for template in (self - unique_variants):
+        multi_variants = self.filtered(
+            lambda template: len(template.product_variant_ids) > 1)
+        for template in multi_variants:
             template.default_code = template.code_prefix
 
     def _get_attr_val_k(self, attr_value_id):
@@ -133,8 +108,16 @@ class ProductTemplate(models.Model):
             'product_variant_default_code'
             '.group_product_default_code')
 
+    def _synchronyze_default_code(self, vals):
+        if 'code_prefix' in vals and \
+                not self._context.get('write_product_product') and \
+                not self._context.get('create_product_product'):
+            vals['default_code'] = vals['code_prefix']
+        return vals
+
     @api.model
     def create(self, vals):
+        self._synchronyze_default_code(vals)
         product = self.new(vals)
         if self._is_automatic_mask() or not vals.get('reference_mask'):
             vals['reference_mask'] = product._get_default_mask()
@@ -145,10 +128,17 @@ class ProductTemplate(models.Model):
     def _mask_needs_update(self, vals):
         return 'code_prefix' in vals or 'attribute_line_ids' in vals
 
+    @api.onchange('reference_mask')
+    def onchange_reference_mask(self):
+        for record in self:
+            if not record.reference_mask:
+                record.reference_mask = record._get_default_mask()
+
     def write(self, vals):
-        result = super(ProductTemplate, self).write(vals)
-        if (self._is_automatic_mask() and self._mask_needs_update(vals)) \
-                or ('reference_mask' in vals and not vals['reference_mask']):
+        self._synchronyze_default_code(vals)
+        result = super(ProductTemplate, self.with_context(
+            write_from_tmpl=True)).write(vals)
+        if (self._is_automatic_mask() and self._mask_needs_update(vals)):
             for record in self:
                 # we write the new mask and the additional write
                 # will recompute the variant code
@@ -157,7 +147,9 @@ class ProductTemplate(models.Model):
             cond = [('product_tmpl_id', 'in', self.ids),
                     ('manual_code', '=', False)]
             for product in self.env['product.product'].search(cond):
-                render_default_code(product, product.reference_mask)
+                product.with_context(
+                    write_from_tmpl=True
+                ).render_default_code()
         return result
 
     @api.model
@@ -179,19 +171,59 @@ class ProductProduct(models.Model):
 
     manual_code = fields.Boolean(string='Manual Reference')
 
+    def _get_rendered_default_code(self):
+        product_attrs = defaultdict(str)
+        reference_mask = ReferenceMask(self.reference_mask)
+        main_lang = self.product_tmpl_id._guess_main_lang()
+        for value in self.attribute_value_ids:
+            attr_name = value.attribute_id.with_context(lang=main_lang).name
+            if value.attribute_id.code:
+                product_attrs[attr_name] += value.attribute_id.code
+            if value.code:
+                product_attrs[attr_name] += value.code
+        all_attrs = extract_token(self.reference_mask)
+        missing_attrs = all_attrs - set(product_attrs.keys())
+        missing = dict.fromkeys(
+            missing_attrs,
+            self.env['ir.config_parameter'].get_param(
+                'default_reference_missing_placeholder'))
+        product_attrs.update(missing)
+        default_code = reference_mask.safe_substitute(product_attrs)
+        return default_code
+
+    def render_default_code(self):
+        for record in self:
+            record.default_code = record._get_rendered_default_code()
+
     @api.model
     def create(self, vals):
+        if not vals.get('product_tmpl_id') and vals.get('default_code'):
+            vals['code_prefix'] = vals['default_code']
         product = super(ProductProduct, self).create(vals)
         if product.reference_mask:
-            render_default_code(product, product.reference_mask)
+            product.render_default_code()
         return product
+
+    def write(self, vals):
+        if 'default_code' in vals and \
+                not self._context.get('create_from_tmpl') and \
+                not self._context.get('write_from_tmpl'):
+            for record in self:
+                local_vals = vals.copy()
+                if not record.attribute_line_ids:
+                    local_vals['code_prefix'] = local_vals['default_code']
+                super(ProductProduct, record.with_context(
+                    write_product_product=True)).write(local_vals)
+            return True
+        else:
+            return super(ProductProduct, self).write(vals)
 
     @api.onchange('default_code')
     def onchange_default_code(self):
         for product in self:
             # it shouldn't be possible to be in 'manual_code' mode
             # when there is only 1 variant
-            if product.product_variant_count > 1:
+            if product.attribute_line_ids:
                 self.manual_code = bool(self.default_code)
 
 
@@ -214,7 +246,7 @@ class ProductAttribute(models.Model):
             'product_tmpl_id').mapped('product_variant_ids').filtered(
                 lambda x: x.product_tmpl_id.reference_mask and not
                 x.manual_code):
-            render_default_code(product, product.reference_mask)
+            product.render_default_code()
         return result
 
 
@@ -247,5 +279,5 @@ class ProductAttributeValue(models.Model):
                 lambda x: x.product_tmpl_id.reference_mask and not
                 x.manual_code
                 ).mapped('product_tmpl_id').mapped('product_variant_ids'):
-            render_default_code(product, product.reference_mask)
+            product.render_default_code()
         return result

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -98,6 +98,14 @@ class ProductTemplate(models.Model):
              '\nNote: make sure characters "[,]" do not appear in your '
              'attribute name')
 
+    @api.depends('product_variant_ids', 'product_variant_ids.default_code')
+    def _compute_default_code(self):
+        super(ProductTemplate, self)._compute_default_code()
+        unique_variants = self.filtered(
+            lambda template: len(template.product_variant_ids) == 1)
+        for template in (self - unique_variants):
+            template.default_code = template.code_prefix
+
     def _get_attr_val_k(self, attr_value_id):
         return attr_value_id.attribute_id.sequence
 

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -88,6 +88,7 @@ class TestVariantDefaultCode(common.SavepointCase):
         self.env.user.groups_id |= self.group_default_code
         # Erase the previous mask: 'P01/[TSize][TColor]'
         self.template2.write({'reference_mask': ''})
+        self.template2.onchange_reference_mask()
         # Mask is set to default now:
         self.assertEqual(self.template2.reference_mask, '[TSize]-[TColor]')
 
@@ -172,6 +173,7 @@ class TestVariantDefaultCode(common.SavepointCase):
             'default_reference_separator', 'None')
         # re-initialize reference mask
         self.template2.write({'reference_mask': ''})
+        self.template2.onchange_reference_mask()
         self.assertEqual(self.template2.reference_mask, '[TSize][TColor]')
 
     def test_12_check_code_prefix_modification(self):
@@ -196,3 +198,25 @@ class TestVariantDefaultCode(common.SavepointCase):
             ]
         })
         self.assertEqual(self.template3.reference_mask, '[TSize]-[TColor]')
+
+    def test_15_check_create_edit_variant(self):
+        variant = self.env['product.product'].create({
+            'name': 'create_variant',
+            'default_code': '123456'
+        })
+        self.assertEqual(variant.product_tmpl_id.code_prefix, '123456')
+        variant.write({
+            'default_code': '99999'
+        })
+        self.assertEqual(variant.product_tmpl_id.code_prefix, '99999')
+
+    def test_16_check_create_edit_template(self):
+        template = self.env['product.template'].create({
+            'name': 'create_template',
+            'code_prefix': '654321'
+        })
+        self.assertEqual(template.product_variant_ids.default_code, '654321')
+        template.write({
+            'code_prefix': '111111'
+        })
+        self.assertEqual(template.product_variant_ids.default_code, '111111')

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -6,11 +6,9 @@
         <field name="inherit_id"
                ref="product.product_template_only_form_view"/>
         <field name="arch" type="xml">
-            <field name="default_code" position="after">
-                <field name="code_prefix"
-                       attrs="{'invisible':
-                          [('attribute_line_ids', '=', [])]}"/>
-                <field name="reference_mask" placeholder="[attribute3]-[attribute1]"
+            <field name="default_code" position="replace">
+                <field name="code_prefix"/>
+                <field name="reference_mask" placeholder="reference[attribute3]-[attribute1]"
                        attrs="{'invisible':
                           [('attribute_line_ids', '=', [])]}"
                        groups="product_variant_default_code.group_product_default_code"/>

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id"
                ref="product.product_template_only_form_view"/>
         <field name="arch" type="xml">
-            <field name="default_code" position="replace">
+            <field name="default_code" attrs="{'invisible': True}" position="after">
                 <field name="code_prefix"/>
                 <field name="reference_mask" placeholder="reference[attribute3]-[attribute1]"
                        attrs="{'invisible':

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -21,7 +21,8 @@
         <field name="inherit_id" ref="product.product_normal_form_view"/>
         <field name="arch" type="xml">
             <field name="default_code" position="before">
-                <field name="manual_code" />
+                <field name="manual_code" attrs="{'invisible':
+                          [('product_variant_count', '=', 1)]}"/>
             </field>
         </field>
     </record>
@@ -31,7 +32,8 @@
         <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
         <field name="arch" type="xml">
             <field name="default_code" position="before">
-                <field name="manual_code" />
+                <field name="manual_code" attrs="{'invisible':
+                          [('product_variant_count', '=', 1)]}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
From this issue : https://github.com/OCA/product-variant/issues/93
