### PR TITLE
[10.0][FIX][product_variant_configurator][sale_variant_configurator]  Variant extra prices are not taken into account right now when selecti

### DIFF
--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -41,6 +41,11 @@ class ProductProduct(models.Model):
         if product_template:
             domain.append(('product_tmpl_id', '=', product_template.id))
             for attr_line in product_attributes:
+                # We need this hack to trigger the compute function,
+                # otherwise attr_line.price_extra always returns 0.0
+                # here (possible Odoo bug, it seems Odoo does not behave
+                # well with a computed variable on NewID 'child' of another NewID)
+                attr_line.value_id = attr_line.value_id
                 if isinstance(attr_line, dict):
                     value_id = attr_line.get('value_id')
                 else:

--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -44,7 +44,7 @@ class ProductProduct(models.Model):
                 # We need this hack to trigger the compute function,
                 # otherwise attr_line.price_extra always returns 0.0
                 # here (possible Odoo bug, it seems Odoo does not behave
-                # well with a computed variable on NewID 'child' of another 
+                # well with a computed variable on NewID 'child' of another
                 # NewID)
                 attr_line.value_id = attr_line.value_id
                 if isinstance(attr_line, dict):

--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -44,7 +44,8 @@ class ProductProduct(models.Model):
                 # We need this hack to trigger the compute function,
                 # otherwise attr_line.price_extra always returns 0.0
                 # here (possible Odoo bug, it seems Odoo does not behave
-                # well with a computed variable on NewID 'child' of another NewID)
+                # well with a computed variable on NewID 'child' of another 
+                # NewID)
                 attr_line.value_id = attr_line.value_id
                 if isinstance(attr_line, dict):
                     value_id = attr_line.get('value_id')

--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -128,7 +128,11 @@ class SaleOrderLine(models.Model):
             fiscal_position=self.env.context.get('fiscal_position')
         )
         price = self.env['account.tax']._fix_tax_included_price_company(
-            self.price_extra + self._get_display_price(product_tmpl),
+            product_tmpl.uom_id._compute_price(
+                self.price_extra,
+                self.env['product.uom'].browse(
+                    product_tmpl._context['uom'])) +
+            self._get_display_price(product_tmpl),
             product_tmpl.taxes_id,
             self.tax_id, self.company_id)
         if self.price_unit != price:

--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -127,10 +127,10 @@ class SaleOrderLine(models.Model):
             uom=self.product_uom.id,
             fiscal_position=self.env.context.get('fiscal_position')
         )
-        price = self.env['account.tax']._fix_tax_included_price(
+        price = self.env['account.tax']._fix_tax_included_price_company(
             self.price_extra + self._get_display_price(product_tmpl),
             product_tmpl.taxes_id,
-            self.tax_id)
+            self.tax_id, self.company_id)
         if self.price_unit != price:
             self.price_unit = price
 
@@ -148,5 +148,6 @@ class SaleOrderLine(models.Model):
         """Update price for having into account changes due to qty"""
         res = super(SaleOrderLine, self).product_uom_change()
         if not self.product_id:
+            self._onchange_product_attribute_ids_configurator()
             self._update_price_configurator()
         return res


### PR DESCRIPTION
To solve this problem, we had to create this hack to trigger the compute
function, otherwise attr_line.price_extra always returns 0.0 here
(possible Odoo bug, it seems Odoo does not behave well with a computed
variable on NewID 'child' of another NewID)

The problem of attribute values has been fixed, but they are not
calculating well in _update_price_configurator when changing
product_uom.

We have to make deeper changes