### PR TITLE
[FIX] 10.0 product_variant_default_code multi-company support

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -275,7 +275,7 @@ class ProductAttributeValue(models.Model):
         if 'code' not in vals:
             return result
         # Rewrite reference on all product variants affected
-        for product in self.mapped('product_ids').filtered(
+        for product in self.sudo().mapped('product_ids').filtered(
                 lambda x: x.product_tmpl_id.reference_mask and not
                 x.manual_code
                 ).mapped('product_tmpl_id').mapped('product_variant_ids'):


### PR DESCRIPTION
Before this fix, if you update a product attribute value code, only the products (default_code) of you company will be updated accordingly.

This fix corrects this behaviour.

For reference : https://github.com/OCA/product-attribute/pull/380 