### PR TITLE
[IMP] sale_order_variant_mgmt: Default values are not applied with new

### DIFF
--- a/sale_order_variant_mgmt/wizard/sale_manage_variant.py
+++ b/sale_order_variant_mgmt/wizard/sale_manage_variant.py
@@ -77,12 +77,14 @@ class SaleManageVariant(models.TransientModel):
                 else:
                     order_line.product_uom_qty = line.product_uom_qty
             elif line.product_uom_qty:
-                order_line = OrderLine.new({
+                vals = OrderLine.default_get(OrderLine._fields.keys())
+                vals.update({
                     'product_id': product.id,
                     'product_uom': product.uom_id,
                     'product_uom_qty': line.product_uom_qty,
                     'order_id': sale_order.id,
                 })
+                order_line = OrderLine.new(vals)
                 order_line.product_id_change()
                 order_line_vals = order_line._convert_to_write(
                     order_line._cache)


### PR DESCRIPTION
This is a flaw/design decision on `new` method, so we have to call it explicitly for getting same result as real records.

@Tecnativa