### PR TITLE
[FIX] *_variant_configurator: attribute lines are not created

### DIFF
--- a/purchase_variant_configurator/__manifest__.py
+++ b/purchase_variant_configurator/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Purchase - Product variants",
     "summary": "Product variants in purchase management",
-    'version': '10.0.1.1.0',
+    'version': '10.0.2.1.0',
     "license": "AGPL-3",
     "depends": [
         "purchase",

--- a/purchase_variant_configurator/views/inherited_purchase_order_views.xml
+++ b/purchase_variant_configurator/views/inherited_purchase_order_views.xml
@@ -27,12 +27,12 @@
                                 <field name="attribute_id" />
                                 <field name="possible_value_ids" widget="many2many_tags" invisible="1"/>
                                 <field name="product_tmpl_id" invisible="1"/>
-                                <field name="value_id"/>
+                                <field name="value_id" context="{'show_attribute': False, 'default_attribute_id': attribute_id, 'template_for_attribute_value': product_tmpl_id}"/>
                             </tree>
                         </field>
                         <field name="can_create_product" invisible="1"/>
                         <field name="create_product_variant"
-                            attrs="{'invisible': 
+                            attrs="{'invisible':
                             [('can_create_product', '=', False)]}"/>
                     </group>
                 </xpath>

--- a/sale_variant_configurator/__manifest__.py
+++ b/sale_variant_configurator/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Sale - Product variants",
     "summary": "Product variants in sale management",
-    "version": "10.0.1.0.0",
+    "version": "10.0.2.0.0",
     "license": "AGPL-3",
     "depends": [
         "sale",

--- a/sale_variant_configurator/views/sale_view.xml
+++ b/sale_variant_configurator/views/sale_view.xml
@@ -29,7 +29,7 @@
                         <field name="attribute_id" />
                         <field name="possible_value_ids" widget="many2many_tags" invisible="1"/>
                         <field name="product_tmpl_id" invisible="1"/>
-                        <field name="value_id"/>
+                        <field name="value_id" context="{'show_attribute': False, 'default_attribute_id': attribute_id, 'template_for_attribute_value': product_tmpl_id}"/>
                         <field name="price_extra"/>
                     </tree>
                 </field>


### PR DESCRIPTION
Propagate context in order to product attribute lines are created.

cc @Tecnativa