### PR TITLE
[10.0] product_variant_default_code do not show default_code on template

### DIFF
--- a/product_variant_default_code/README.rst
+++ b/product_variant_default_code/README.rst
@@ -116,6 +116,7 @@ Contributors
 * Tony Gu <tony@openerp.cn>
 * David Vidal <david.vidal@tecnativa.com>
 * David Beal <david.beal@akretion.com>
+* Pierrick Brun <pierrick.brun@akretion.com>
 
 Maintainer
 ----------

--- a/product_variant_default_code/__manifest__.py
+++ b/product_variant_default_code/__manifest__.py
@@ -7,7 +7,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Product Variant Default Code',
-    'version': '10.0.1.0.2',
+    'version': '10.0.1.0.3',
     'author': 'AvancOSC,'
               'Shine IT,'
               'Tecnativa,'

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -6,7 +6,10 @@
         <field name="inherit_id"
                ref="product.product_template_only_form_view"/>
         <field name="arch" type="xml">
-            <field name="default_code" attrs="{'invisible': True}" position="after">
+            <field name="default_code" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </field>
+            <field name="default_code" position="after">
                 <field name="code_prefix"/>
                 <field name="reference_mask" placeholder="reference[attribute3]-[attribute1]"
                        attrs="{'invisible':


### PR DESCRIPTION
before the PR:
both reference_prefix and default_code are shown on the product_template (before it has variants)

This is confusing because only the reference_prefix should be used, also the default_code will be replaced if used.

after the PR:
only the reference prefix is shown on the template.
You can still view the default_code from the name_get()

It looks like it's what was tried with the attrs="{'invisible': True}".