### PR TITLE
[PERF] Make seller_ids and tmpl_seller_ids stored

### DIFF
--- a/product_variant_supplierinfo/__manifest__.py
+++ b/product_variant_supplierinfo/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Product supplier info per variant',
     'summary': 'Supplier info to product variant scope',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'author': 'Tecnativa, Akretion,'
               'Odoo Community Association (OCA)',
     'category': 'Product Management',

--- a/product_variant_supplierinfo/__manifest__.py
+++ b/product_variant_supplierinfo/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Product supplier info per variant',
     'summary': 'Supplier info to product variant scope',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'author': 'Tecnativa, Akretion,'
               'Odoo Community Association (OCA)',
     'category': 'Product Management',

--- a/product_variant_supplierinfo/models/product_product.py
+++ b/product_variant_supplierinfo/models/product_product.py
@@ -12,7 +12,8 @@ class ProductProduct(models.Model):
 
     seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='_compute_seller_ids')
+        compute='_compute_seller_ids',
+        store=True)
     seller_delay = fields.Integer(
         related='seller_ids.delay',
         string='Supplier Lead Time',
@@ -34,9 +35,11 @@ class ProductProduct(models.Model):
         'product_id')
     tmpl_seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='_compute_seller_ids')
+        compute='_compute_seller_ids',
+        store=True,)
 
     @api.multi
+    @api.depends('product_tmpl_id.seller_ids.product_id')
     def _compute_seller_ids(self):
         for product in self:
             sellers = product.product_tmpl_id.seller_ids

--- a/product_variant_supplierinfo/models/product_product.py
+++ b/product_variant_supplierinfo/models/product_product.py
@@ -12,7 +12,7 @@ class ProductProduct(models.Model):
 
     seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='_compute_seller_ids',
+        compute='compute_seller_ids',
         store=True)
     seller_delay = fields.Integer(
         related='seller_ids.delay',
@@ -35,15 +35,13 @@ class ProductProduct(models.Model):
         'product_id')
     tmpl_seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='_compute_seller_ids',
+        compute='compute_seller_ids',
         store=True,)
 
     @api.multi
     @api.depends('product_tmpl_id.seller_ids.product_id')
-    def _compute_seller_ids(self):
+    def compute_seller_ids(self):
         for product in self:
             sellers = product.product_tmpl_id.seller_ids
-            product.tmpl_seller_ids = sellers.filtered(
-                lambda x: not x.product_id)
-            product.seller_ids = sellers.filtered(
-                lambda x: not x.product_id or x.product_id == product)
+            product.tmpl_seller_ids = sellers
+            product.seller_ids = sellers.filtered(lambda x: x.product_id == product)

--- a/product_variant_supplierinfo/models/product_product.py
+++ b/product_variant_supplierinfo/models/product_product.py
@@ -12,8 +12,7 @@ class ProductProduct(models.Model):
 
     seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='_compute_seller_ids',
-        store=True)
+        compute='_compute_seller_ids')
     seller_delay = fields.Integer(
         related='seller_ids.delay',
         string='Supplier Lead Time',
@@ -35,11 +34,9 @@ class ProductProduct(models.Model):
         'product_id')
     tmpl_seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='_compute_seller_ids',
-        store=True,)
+        compute='_compute_seller_ids')
 
     @api.multi
-    @api.depends('product_tmpl_id.seller_ids.product_id')
     def _compute_seller_ids(self):
         for product in self:
             sellers = product.product_tmpl_id.seller_ids

--- a/product_variant_supplierinfo/models/product_product.py
+++ b/product_variant_supplierinfo/models/product_product.py
@@ -12,7 +12,7 @@ class ProductProduct(models.Model):
 
     seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='compute_seller_ids',
+        compute='_compute_seller_ids',
         store=True)
     seller_delay = fields.Integer(
         related='seller_ids.delay',
@@ -35,13 +35,15 @@ class ProductProduct(models.Model):
         'product_id')
     tmpl_seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='compute_seller_ids',
+        compute='_compute_seller_ids',
         store=True,)
 
     @api.multi
     @api.depends('product_tmpl_id.seller_ids.product_id')
-    def compute_seller_ids(self):
+    def _compute_seller_ids(self):
         for product in self:
             sellers = product.product_tmpl_id.seller_ids
-            product.tmpl_seller_ids = sellers
-            product.seller_ids = sellers.filtered(lambda x: x.product_id == product)
+            product.tmpl_seller_ids = sellers.filtered(
+                lambda x: not x.product_id)
+            product.seller_ids = sellers.filtered(
+                lambda x: not x.product_id or x.product_id == product)


### PR DESCRIPTION
When confirming complex sales orders, calls to `product.seller_ids`
in `name_get()` and `select_seller()` result in the ORM re-calculating this fields
values for many products due to running out of cache (i believe).

This result in ~6s compute time per line being wasted on re-running the lambdas.
In my case this compute function was being hit 800,000 times on a 8 line SO.
Making the field stored resolves this issue,
but obviously has some impact when initially installing the module.

There appears to be no detrimental effects to making this change,
once the module is installed.