### PR TITLE
[10.0][FIX] sale_variant_configurator: Does not return the inherited result

### DIFF
--- a/sale_variant_configurator/README.rst
+++ b/sale_variant_configurator/README.rst
@@ -35,6 +35,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Ana Juaristi <ajuaristio@gmail.com>
 * David Vidal <david.vidal@tecnativa.com>
+* Isaac Gallart <igallart@puntsistemes.es>
 
 Maintainer
 ----------

--- a/sale_variant_configurator/__manifest__.py
+++ b/sale_variant_configurator/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Sale - Product variants",
     "summary": "Product variants in sale management",
-    "version": "10.0.2.1.0",
+    "version": "10.0.2.1.1",
     "license": "AGPL-3",
     "depends": [
         "sale",

--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -49,7 +49,7 @@ class SaleOrder(models.Model):
         )
         for line in lines_without_product:
             line.create_variant_if_needed()
-        super(SaleOrder, self).action_confirm()
+        return super(SaleOrder, self).action_confirm()
 
 
 class SaleOrderLine(models.Model):


### PR DESCRIPTION
By not returning the inherited result, some methods like https://github.com/OCA/partner-contact/blob/b2835680c05a9c1c3853c766604797b992b74ba8/partner_sale_risk/models/sale.py#L37 do not work and the user does not know what has happened.