### PR TITLE
[IMP] sale_order_variant_mgmt: Play all onchanges

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
+server-tools
 web

--- a/sale_order_variant_mgmt/README.rst
+++ b/sale_order_variant_mgmt/README.rst
@@ -36,8 +36,9 @@ screen without the need of handling them one by one
 Installation
 ============
 
-This module requires the module web_widget_x2many_2d_matrix, which is located
-at OCA/web repository.
+This module requires the module `web_widget_x2many_2d_matrix`, which is located
+at OCA/web repository, and `onchange_helper`, which is located at
+OCA/server-tools.
 
 Configuration
 =============

--- a/sale_order_variant_mgmt/__manifest__.py
+++ b/sale_order_variant_mgmt/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Handle easily multiple variants on Sales Orders',
     'summary': 'Handle the addition/removal of multiple variants from '
                'product template into the sales order',
-    'version': '11.0.1.0.1',
+    'version': '11.0.2.0.0',
     'author': 'Tecnativa,'
               'Odoo Community Association (OCA)',
     'category': 'Sale',
@@ -13,6 +13,7 @@
     'website': 'https://www.tecnativa.com',
     'depends': [
         'sale',
+        'onchange_helper',
         'web_widget_x2many_2d_matrix',
     ],
     'demo': [],

--- a/sale_order_variant_mgmt/readme/INSTALL.rst
+++ b/sale_order_variant_mgmt/readme/INSTALL.rst
@@ -1,2 +1,3 @@
-This module requires the module web_widget_x2many_2d_matrix, which is located
-at OCA/web repository.
+This module requires the module `web_widget_x2many_2d_matrix`, which is located
+at OCA/web repository, and `onchange_helper`, which is located at
+OCA/server-tools.

--- a/sale_order_variant_mgmt/static/description/index.html
+++ b/sale_order_variant_mgmt/static/description/index.html
@@ -387,8 +387,9 @@ screen without the need of handling them one by one</p>
 </div>
 <div class="section" id="installation">
 <h1><a class="toc-backref" href="#id1">Installation</a></h1>
-<p>This module requires the module web_widget_x2many_2d_matrix, which is located
-at OCA/web repository.</p>
+<p>This module requires the module <cite>web_widget_x2many_2d_matrix</cite>, which is located
+at OCA/web repository, and <cite>onchange_helper</cite>, which is located at
+OCA/server-tools.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#id2">Configuration</a></h1>

--- a/sale_order_variant_mgmt/wizard/sale_manage_variant.py
+++ b/sale_order_variant_mgmt/wizard/sale_manage_variant.py
@@ -83,15 +83,19 @@ class SaleManageVariant(models.TransientModel):
                 vals = OrderLine.default_get(OrderLine._fields.keys())
                 vals.update({
                     'product_id': product.id,
-                    'product_uom': product.uom_id,
+                    'product_uom': product.uom_id.id,
                     'product_uom_qty': line.product_uom_qty,
                     'order_id': sale_order.id,
                 })
-                order_line = OrderLine.new(vals)
-                order_line.product_id_change()
-                order_line_vals = order_line._convert_to_write(
-                    order_line._cache)
-                sale_order.order_line.browse().create(order_line_vals)
+                vals = OrderLine.play_onchanges(
+                    vals, [
+                        'order_id',
+                        'product_id',
+                        'product_uom',
+                        'product_uom_qty',
+                    ],
+                )
+                OrderLine.create(vals)
         lines2unlink.unlink()
 
 


### PR DESCRIPTION
There are third-party modules that can add onchanges to the fields that this module is setting in sale.order.line, so this is the only way to ensure proper line creation.

This means the introduction of a new dependency in a stable branch, but it's worth IMO. What others think?

cc @Tecnativa