### PR TITLE
show lst_price in product form

### DIFF
--- a/product_variant_sale_price/views/product_view.xml
+++ b/product_variant_sale_price/views/product_view.xml
@@ -18,10 +18,9 @@
        <field name="model">product.product</field>
        <field name="inherit_id" ref="product.product_normal_form_view" />
        <field name="arch" type="xml">
-            <xpath expr="//field[@name='uom_id']" position="after">
-                <field name="fix_price"
-                       attrs="{'invisible': [('product_variant_count', '=', 1)]}"/>
-            </xpath>
+           <field name="lst_price" position="attributes">
+               <attribute name="attrs">{'readonly': [('product_variant_count', '=', 1)]}</attribute>
+           </field>
        </field>
     </record>
 


### PR DESCRIPTION
I might be wrong but it seems that lst_price should be shown in the product form instead of fix_price and fix_price should never be shown.
otherwise the method _inverse_product_lst_price of field lst_price is never called and the product template list_price is never updated.
What I understand is that the fix_price is a hidden value that has to be filled by the inverse method of field lst_price.