### PR TITLE
[11.0][IMP] product_variant_sale_price Uom price is calcultaed twice

### DIFF
--- a/product_variant_sale_price/models/product_product.py
+++ b/product_variant_sale_price/models/product_product.py
@@ -46,9 +46,6 @@ class ProductProduct(models.Model):
         uom_model = self.env['product.uom']
         for product in self:
             price = product.fix_price or product.product_tmpl_id.list_price
-            if 'uom' in self.env.context:
-                price = product.uom_id._compute_price(
-                    price, uom_model.browse(self.env.context['uom']))
             product.list_price = price
 
     @api.multi


### PR DESCRIPTION
Problem here is for example if you create a new sale order, with a hourly rate product with a price of 100.00 per hour, if you change the uom from hour to day, you will get 6'400.00 of unit price instead of 800.00. This is because the uom price is computed twice.
Do not compute uom price here for list_price as it's already done in the product_product price_compute method.