### PR TITLE
fix config help

### DIFF
--- a/product_variant_default_code/models/config_settings.py
+++ b/product_variant_default_code/models/config_settings.py
@@ -13,7 +13,7 @@ class BaseConfiguration(models.TransientModel):
         (1, 'Manual Mask')],
         string='Product Default Code behaviour',
         help='Set behaviour of codes (depends on variant use: '
-             'see Sales/Purchases configuration)',
+             'see Sales/Inventory configuration)',
         implied_group='product_variant_default_code'
                       '.group_product_default_code',
     )


### PR DESCRIPTION
variants are activated in Sale and Inventory, not in Purchase