### PR TITLE
[FIX] compute_list_price

### DIFF
--- a/product_variant_sale_price/models/product_product.py
+++ b/product_variant_sale_price/models/product_product.py
@@ -44,12 +44,8 @@ class ProductProduct(models.Model):
 
     @api.multi
     def _compute_list_price(self):
-        uom_model = self.env['uom.uom']
         for product in self:
             price = product.fix_price or product.product_tmpl_id.list_price
-            if 'uom' in self.env.context:
-                price = product.uom_id._compute_price(
-                    price, uom_model.browse(self.env.context['uom']))
             product.list_price = price
 
     @api.multi


### PR DESCRIPTION
Hi, I'm Oscar.

I have found this problem with the unit  of measure:
In a new DB, I have only installed sale_management and product_variant_sale_price modules, I have created a unit of measure "Three months" with factor_inv = 3.0.
The problem is that when I add a product in a sale.order.line, the calculation of price_unit is wrong.
The calculation is price = list_price * factor_inv, but if I install product_variant_sale_price this calculation is executed twice: price = (list_price * factor_inv)² .

This PR only remove the suspects lines of code.

Thanks a lot.

The following gif shows the problem.

![error_in_product_variant_oca](https://user-images.githubusercontent.com/33620978/72758500-46315d80-3bd3-11ea-98eb-8629c088805f.gif)
