### PR TITLE
[FIX] sale_order_variant_mgmt: Filter attributes

### DIFF
--- a/sale_order_variant_mgmt/tests/test_sale_order_variant_mgmt.py
+++ b/sale_order_variant_mgmt/tests/test_sale_order_variant_mgmt.py
@@ -25,6 +25,14 @@ class TestSaleOrderVariantMgmt(common.SavepointCase):
                 (0, 0, {'name': 'Value Y'}),
             ],
         })
+        cls.attribute3 = cls.env['product.attribute'].create({
+            'name': 'Test Attribute 3',
+            'value_ids': [
+                (0, 0, {'name': 'Value A'}),
+                (0, 0, {'name': 'Value Z'}),
+            ],
+            'create_variant': 'no_variant',
+        })
         cls.product_tmpl = cls.env['product.template'].create({
             'name': 'Test template',
             'attribute_line_ids': [
@@ -35,6 +43,10 @@ class TestSaleOrderVariantMgmt(common.SavepointCase):
                 (0, 0, {
                     'attribute_id': cls.attribute2.id,
                     'value_ids': [(6, 0, cls.attribute2.value_ids.ids)],
+                }),
+                (0, 0, {
+                    'attribute_id': cls.attribute3.id,
+                    'value_ids': [(6, 0, cls.attribute3.value_ids.ids)],
                 }),
             ],
         })

--- a/sale_order_variant_mgmt/wizard/sale_manage_variant.py
+++ b/sale_order_variant_mgmt/wizard/sale_manage_variant.py
@@ -36,7 +36,7 @@ class SaleManageVariant(models.TransientModel):
         else:
             sale_order = record
         attr_lines = template.attribute_line_ids.filtered(
-            lambda x: x.attribute_id.create_variant
+            lambda x: x.attribute_id.create_variant != 'no_variant'
         )
         num_attrs = len(attr_lines)
         if not template or not num_attrs or num_attrs > 2:


### PR DESCRIPTION
Previous this commit, variant wizard will not shown attributes from product templates with more than two attributes (in all cases). This commit fixes the filter to not count attributes that doesn't generate variants.

cc @tecnativa TT21833