### PR TITLE
[12.0][FIX] if a product already have a code do not change it

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -203,7 +203,7 @@ class ProductAttributeValue(models.Model):
 
     @api.onchange('name')
     def onchange_name(self):
-        if self.name:
+        if self.name and not self.code:
             self.code = self.name[0:2]
 
     code = fields.Char(


### PR DESCRIPTION
When modify a attribute value (fixing a typo for example).
The onchange will change the code of the attribute.
This may generate a lot of mistake as user can change the code of an attribute value by mistake and set a wrong value