### PR TITLE
[13.0] product_variant_default_code improvements

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -81,21 +81,21 @@ class ProductTemplate(models.Model):
         help="Reference mask for building internal references of a "
         "variant generated from this template.\n"
         "Example:\n"
-        "A product named ABC with 2 attributes: Size and Color:\n"
+        "A product named ABC with 2 attributes: Size(S) and Color(C):\n"
         "Product: ABC\n"
         "Color: Red(r), Yellow(y), Black(b)  #Red, Yellow, Black are "
         "the attribute value, `r`, `y`, `b` are the corresponding code\n"
         "Size: L (l), XL(x)\n"
         "When setting Variant reference mask to `[Color]-[Size]`, the "
-        "default code on the variants will be something like `r-l` "
-        "`b-l` `r-x` ...\n"
+        "default code on the variants will be something like `Cr-Sl` "
+        "`Cb-Sl` `Cr-Sx` ...\n"
         "If you like, You can even have the attribute name appear more"
         " than once in the mask. Such as,"
         "`fancyA/[Size]~[Color]~[Size]`\n"
         " When saved, the default code on variants will be "
         "something like \n"
-        ' `fancyA/l~r~l` (for variant with Color "Red" and Size "L") '
-        ' `fancyA/x~y~x` (for variant with Color "Yellow" and Size "XL")'
+        ' `fancyA/Sl~Cr~Sl` (for variant with Color "Red" and Size "L") '
+        ' `fancyA/Sx~Cy~Sx` (for variant with Color "Yellow" and Size "XL")'
         '\nNote: make sure characters "[,]" do not appear in your '
         "attribute name",
     )

--- a/product_variant_default_code/readme/CONFIGURATION.rst
+++ b/product_variant_default_code/readme/CONFIGURATION.rst
@@ -1,0 +1,12 @@
+To configure the automatic generation of Product Reference, you need to:
+
+#. Go to ``Settings > General Settings``, and check "Product Default Code
+   Manual Mask" on "Product Variants" section if you want to manually set
+   up mask for each Product Template. If you want to use default mask leave
+   the chekbox unchecked.
+#. Go to ``Sales > Catalog > Products``, and select a product.
+#. On the General Information tab edit the value of the field
+   ``Reference Prefix`` for automatic mask creation. The value will be used as
+   a delimiter between individual attribute values (codes).
+#. If you selected "Product Default Code Manual Mask" in Settings you will be
+   able to set up mask for that Product Template.

--- a/product_variant_default_code/readme/CONTRIBUTORS.rst
+++ b/product_variant_default_code/readme/CONTRIBUTORS.rst
@@ -2,6 +2,7 @@
 * Tony Gu <tony@openerp.cn>
 * David Beal <david.beal@akretion.com>
 * Daniel Campos <danielcampos@avanzosc.es>
+* Radovan Skolnik <radovan@skolnik.info>
 
 * Tecnativa <tecnativa.com>:
   * David Vidal

--- a/product_variant_default_code/readme/DESCRIPTION.rst
+++ b/product_variant_default_code/readme/DESCRIPTION.rst
@@ -6,13 +6,13 @@ variants references are automatically set. For example:
 
 - Product template: Jacket
 - Attributes:
-  - Color: White, Black
-  - Size: M, L
+  - Color(C): White(Wh), Black(Bl)
+  - Size(S): M(M), L(L)
 - Reference mask: `JKT01-[Color]-[Size]`
 
 - Reference on variants:
 
-  - `JKT01-Wh-M` Jacket White M
-  - `JKT01-Bl-M` Jacket Black M
-  - `JKT01-Wh-L` Jacket White L
-  - `JKT01-Bl-L` Jacket Black L
+  - `JKT01-CWh-SM` Jacket White M
+  - `JKT01-CBl-SM` Jacket Black M
+  - `JKT01-CWh-SL` Jacket White L
+  - `JKT01-CBl-SL` Jacket Black L

--- a/product_variant_default_code/readme/USAGE.rst
+++ b/product_variant_default_code/readme/USAGE.rst
@@ -31,7 +31,7 @@ something like `Jacket/L~Bl~L` (for variant with Color "Black" and Size "L").
 When the code attribute is changed, it automatically regenerates the 'default
 code' on all variants affected.
 
-Aditionally, a product attribute can be set and so it will be appended to the
+Aditionally, a product attribute can be set and so it will be prepended to the
 product `default_code`. In the first example, setting a `Color` code to `CO`
 would give `default_code` like this: `COBl-L`, `COWh-L`, `COBl-XL` and
 `COWh-XL`.

--- a/product_variant_default_code/views/product_attribute_view.xml
+++ b/product_variant_default_code/views/product_attribute_view.xml
@@ -27,6 +27,9 @@
         <field name="model">product.attribute</field>
         <field name="inherit_id" ref="product.product_attribute_view_form" />
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="code" />
+            </xpath>
             <xpath
                 expr="//field[@name='value_ids']//field[@name='name']"
                 position="after"


### PR DESCRIPTION
After playing with this module (which I found very useful) I felt the need to do few improvements:

- allow for editing of product.attribute code
- enhance the documentation here and there to show where that code might be used
- enhance the documentation with System Settings and code_prefix usage
