### PR TITLE
[FIX] sale_order_variant_mgmt: Filter no_variant attributes

### DIFF
--- a/purchase_order_variant_mgmt/__manifest__.py
+++ b/purchase_order_variant_mgmt/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Handle easily multiple variants on Purchase Orders',
     'summary': 'Handle the addition/removal of multiple variants from '
                'product template into the purchase order',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'author': 'Tecnativa,'
               'Odoo Community Association (OCA)',
     'category': 'Purchases',

--- a/purchase_order_variant_mgmt/tests/test_purchase_order_variant_mgmt.py
+++ b/purchase_order_variant_mgmt/tests/test_purchase_order_variant_mgmt.py
@@ -23,6 +23,14 @@ class TestPurchaseOrderVariantMgmt(common.SavepointCase):
                 (0, 0, {'name': 'Value Y'}),
             ],
         })
+        cls.attribute3 = cls.env['product.attribute'].create({
+            'name': 'Test Attribute 3',
+            'value_ids': [
+                (0, 0, {'name': 'Value A'}),
+                (0, 0, {'name': 'Value Z'}),
+            ],
+            'create_variant': 'no_variant',
+        })
         cls.product_tmpl = cls.env['product.template'].create({
             'name': 'Test template',
             'attribute_line_ids': [
@@ -33,6 +41,10 @@ class TestPurchaseOrderVariantMgmt(common.SavepointCase):
                 (0, 0, {
                     'attribute_id': cls.attribute2.id,
                     'value_ids': [(6, 0, cls.attribute2.value_ids.ids)],
+                }),
+                (0, 0, {
+                    'attribute_id': cls.attribute3.id,
+                    'value_ids': [(6, 0, cls.attribute3.value_ids.ids)],
                 }),
             ],
         })

--- a/purchase_order_variant_mgmt/wizard/purchase_manage_variant.py
+++ b/purchase_order_variant_mgmt/wizard/purchase_manage_variant.py
@@ -38,11 +38,14 @@ class PurchaseManageVariant(models.TransientModel):
             purchase_order = record.order_id
         else:
             purchase_order = record
-        num_attrs = len(template.attribute_line_ids)
-        if not template or not num_attrs:
+        attr_lines = template.attribute_line_ids.filtered(
+            lambda x: x.attribute_id.create_variant != 'no_variant'
+        )
+        num_attrs = len(attr_lines)
+        if not template or not attr_lines or num_attrs > 2:
             return
-        line_x = template.attribute_line_ids[0]
-        line_y = False if num_attrs == 1 else template.attribute_line_ids[1]
+        line_x = attr_lines[0]
+        line_y = False if num_attrs == 1 else attr_lines[1]
         lines = []
         for value_x in line_x.value_ids:
             for value_y in line_y and line_y.value_ids or [False]:


### PR DESCRIPTION
Previous to this commit, in purchase orders, variant wizard will not show options from product templates with more than two attributes, even these are configured to not creating variants. This commit filter attributes that don't generate variants.