### PR TITLE
[FIX] product_variant_default_code: fix onchange code value

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -216,8 +216,9 @@ class ProductAttributeValue(models.Model):
 
     @api.onchange("name")
     def onchange_name(self):
-        if self.name:
-            self.code = self.name[0:2]
+        """Set a default code for the value"""
+        if self.name and not self.code:
+            self.code = self.name[:2]
 
     code = fields.Char(
         string="Attribute Value Code",

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -169,9 +169,10 @@ class TestVariantDefaultCode(common.SavepointCase):
             self.assertTrue("OO" in product.default_code)
 
     def test_07_attribute_value_name_change(self):
-        self.attr1_1.name = "Odoo"
+        """Only set a default code if it wasn't set"""
+        self.attr1_1.name = "New Name"
         self.attr1_1.onchange_name()
-        self.assertEqual(self.attr1_1.code, "Od")
+        self.assertEqual(self.attr1_1.code, "L")
         products = self.env["product.product"].search(
             [
                 (
@@ -181,7 +182,14 @@ class TestVariantDefaultCode(common.SavepointCase):
                 )
             ]
         )
-        # Check that the change spreads to every product
+        # Check that the code persists
+        for product in products:
+            self.assertTrue("L" in product.default_code)
+        # Otherwise, if there's no code a default value is set
+        self.attr1_1.code = False
+        self.attr1_1.name = "Odoo"
+        self.attr1_1.onchange_name()
+        self.assertEqual(self.attr1_1.code, "Od")
         for product in products:
             self.assertTrue("Od" in product.default_code)
 


### PR DESCRIPTION
When an attribute code is already set, we don't wan't to change it by
chance if we set a new name in the value. The onchange should be just a
helper to fill the initial value but it should be manually changed if
needed later on.

cc @Tecnativa TT28258