### PR TITLE
[13.0] [FIX] product_variant_configurator: attribute readonly

### DIFF
--- a/product_variant_configurator/models/product_configurator_attribute.py
+++ b/product_variant_configurator/models/product_configurator_attribute.py
@@ -25,7 +25,7 @@ class ProductConfiguratorAttribute(models.Model):
         comodel_name="product.template", string="Product Template", required=True
     )
     attribute_id = fields.Many2one(
-        comodel_name="product.attribute", string="Attribute", readonly=False
+        comodel_name="product.attribute", string="Attribute", readonly=True
     )
     value_id = fields.Many2one(
         comodel_name="product.attribute.value",


### PR DESCRIPTION
Attribute must be readonly. Probably a bug introduced during the migration.