### PR TITLE
[13.0][ADD] product_variant_change_attribute_value

### DIFF
--- a/product_variant_change_attribute_value/__init__.py
+++ b/product_variant_change_attribute_value/__init__.py
@@ -1,0 +1,2 @@
+from . import tests
+from . import wizards

--- a/product_variant_change_attribute_value/__manifest__.py
+++ b/product_variant_change_attribute_value/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Product Variant Change Attribute Value",
+    "version": "13.0.1.0.0",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/product-variant",
+    "license": "AGPL-3",
+    "category": "Product Variant",
+    "depends": ["product"],
+    "data": ["wizards/product_variant_attribute_value_wizard.xml"],
+    "installable": True,
+}

--- a/product_variant_change_attribute_value/readme/CONTRIBUTORS.rst
+++ b/product_variant_change_attribute_value/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/product_variant_change_attribute_value/readme/DESCRIPTION.rst
+++ b/product_variant_change_attribute_value/readme/DESCRIPTION.rst
@@ -1,11 +1,8 @@
-With standard Odoo there is no way to change the attribute values assigned
+In standard Odoo there is no way to change the attribute values assigned
 to a product variant.
 
-This module adds a wizard that can be access through the product variant
-tree view context action menu.
-
-The wizard allows to change or remove attribute values on all product
+This module adds a wizard to change or remove attribute values on all product
 variant selected.
 
-When an attribute value is removed from all variant of a template,
-it will also be removed from the configuration of the related product template.
+When an attribute value is removed from all variants of a template,
+it will also be removed from the configuration of the template.

--- a/product_variant_change_attribute_value/readme/DESCRIPTION.rst
+++ b/product_variant_change_attribute_value/readme/DESCRIPTION.rst
@@ -1,0 +1,11 @@
+With standard Odoo there is no way to change the attribute values assigned
+to a product variant.
+
+This module adds a wizard that can be access through the product variant
+tree view context action menu.
+
+The wizard allows to change or remove attribute values on all product
+variant selected.
+
+When an attribute value is removed from all variant of a template,
+it will also be removed from the configuration of the related product template.

--- a/product_variant_change_attribute_value/readme/USAGE.rst
+++ b/product_variant_change_attribute_value/readme/USAGE.rst
@@ -1,0 +1,2 @@
+The wizard can be access from the product variant tree view through
+the context action menu `Change attribute values assigned`

--- a/product_variant_change_attribute_value/tests/test_product_variant_change_attribute_value.py
+++ b/product_variant_change_attribute_value/tests/test_product_variant_change_attribute_value.py
@@ -1,0 +1,124 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests import common
+
+
+class TestProductVariantChangeAttributeValue(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.legs = cls.env.ref("product.product_attribute_1")
+        cls.steel = cls.env.ref("product.product_attribute_value_1")
+        cls.aluminium = cls.env.ref("product.product_attribute_value_2")
+
+        cls.color = cls.env.ref("product.product_attribute_2")
+        cls.white = cls.env.ref("product.product_attribute_value_3")
+        cls.black = cls.env.ref("product.product_attribute_value_4")
+        cls.pink = cls.env["product.attribute.value"].create(
+            {"name": "Pink", "attribute_id": cls.color.id}
+        )
+        cls.blue = cls.env["product.attribute.value"].create(
+            {"name": "Blue", "attribute_id": cls.color.id}
+        )
+
+        cls.variant_1 = cls.env.ref("product.product_product_4")
+        cls.variant_2 = cls.env.ref("product.product_product_4b")
+        cls.variant_3 = cls.env.ref("product.product_product_4c")
+        cls.variant_4 = cls.env.ref("product.product_product_4d")
+        cls.variants = [
+            cls.variant_1.id,
+            cls.variant_2.id,
+            cls.variant_3.id,
+            cls.variant_4.id,
+        ]
+        cls.template = cls.variant_1.product_tmpl_id
+        assert len(cls.template.product_variant_ids) == 4
+
+        cls.wizard = cls.env["variant.attribute.value.wizard"]
+
+    def change_action(self, value, action, replaced_by=False):
+        "Set an action to do by the wizard on an attribute value."
+        actions = self.wiz.attributes_action_ids
+        action_id = actions.filtered(lambda r: r.product_attribute_value_id == value)
+        action_id.attribute_action = action
+        action_id.replaced_by = replaced_by
+
+    def is_value_on_variant(self, variant, attribute_value):
+        values = variant.product_template_attribute_value_ids.mapped(
+            "product_attribute_value_id"
+        )
+        return attribute_value in values
+
+    def is_attribute_value_on_template(self, product, attribute_value):
+        """Check if an attribute value is assigned to a variant template."""
+        template = product.product_tmpl_id
+        attribute = attribute_value.attribute_id
+        attribute_line = template.attribute_line_ids.filtered(
+            lambda l: l.attribute_id == attribute
+        )
+        if not attribute_line:
+            return False
+        ptav = self.env["product.template.attribute.value"].search(
+            [
+                ("attribute_line_id", "=", attribute_line.id),
+                ("product_attribute_value_id", "=", attribute_value.id),
+            ]
+        )
+        if not ptav:
+            return False
+        return True
+
+    def test_remove_attribute_value(self):
+        """Check removing an attribute value on ALL variants of a template."""
+        self.assertTrue(self.is_value_on_variant(self.variant_1, self.steel))
+
+        self.wiz = self.wizard.with_context(default_res_ids=self.variants).create({})
+        self.change_action(self.steel, "delete")
+        self.wiz.action_change_attributes()
+
+        self.assertFalse(self.is_value_on_variant(self.variant_1, self.steel))
+        self.assertFalse(
+            self.is_attribute_value_on_template(self.variant_1, self.steel)
+        )
+
+    def test_change_attribure_value(self):
+        """Check changing an attribute value on ALL variant of a template."""
+        self.assertTrue(self.is_value_on_variant(self.variant_1, self.white))
+
+        self.wiz = self.wizard.with_context(default_res_ids=self.variants).create({})
+        self.change_action(self.white, "replace", self.pink)
+        self.wiz.action_change_attributes()
+
+        self.assertFalse(self.is_value_on_variant(self.variant_1, self.white))
+        self.assertTrue(self.is_value_on_variant(self.variant_1, self.pink))
+        # White has been removed from the template
+        self.assertFalse(
+            self.is_attribute_value_on_template(self.variant_1, self.white)
+        )
+
+    def test_change_attribure_value_2(self):
+        """Check changing an attribute value on some variant of a template.
+
+        Changing the value white to pink on variant 3 and 4.
+        """
+        self.assertTrue(self.is_value_on_variant(self.variant_3, self.white))
+        self.assertFalse(self.is_value_on_variant(self.variant_4, self.white))
+        # Variant 1 has the white attribute but is is not picked by the wizard
+        self.assertTrue(self.is_value_on_variant(self.variant_1, self.white))
+
+        self.wiz = self.wizard.with_context(
+            default_res_ids=[self.variant_3.id, self.variant_4.id]
+        ).create({})
+        self.change_action(self.white, "replace", self.pink)
+        self.wiz.action_change_attributes()
+
+        self.assertFalse(self.is_value_on_variant(self.variant_3, self.white))
+        self.assertFalse(self.is_value_on_variant(self.variant_4, self.white))
+        self.assertTrue(self.is_value_on_variant(self.variant_3, self.pink))
+        self.assertFalse(self.is_value_on_variant(self.variant_4, self.pink))
+        # The value should not be remove from the template because of variant 1
+        self.assertTrue(self.is_attribute_value_on_template(self.variant_1, self.white))
+        self.assertTrue(self.is_value_on_variant(self.variant_1, self.white))

--- a/product_variant_change_attribute_value/tests/test_product_variant_change_attribute_value.py
+++ b/product_variant_change_attribute_value/tests/test_product_variant_change_attribute_value.py
@@ -157,7 +157,7 @@ class TestProductVariantChangeAttributeValue(common.SavepointCase):
     def test_active_deactivate_attribute_value_1_step(self):
         """ Deactivate a pav and reactivate it in 1 steps.
 
-        Same than previous tests but both replacement are done in one 
+        Same than previous tests but both replacement are done in one
         execution of the wizard.
 
         """

--- a/product_variant_change_attribute_value/tests/test_product_variant_change_attribute_value.py
+++ b/product_variant_change_attribute_value/tests/test_product_variant_change_attribute_value.py
@@ -70,7 +70,8 @@ class TestProductVariantChangeAttributeValue(common.SavepointCase):
         )
         if not ptav:
             return False
-        return True
+        # Check that it is also active
+        return ptav.ptav_active
 
     def test_remove_attribute_value(self):
         """Check removing an attribute value on ALL variants of a template."""

--- a/product_variant_change_attribute_value/tests/test_product_variant_change_attribute_value.py
+++ b/product_variant_change_attribute_value/tests/test_product_variant_change_attribute_value.py
@@ -100,7 +100,7 @@ class TestProductVariantChangeAttributeValue(common.SavepointCase):
             self._is_attribute_value_on_template(self.variant_1, self.white)
         )
 
-    def test_change_attribure_value_2(self):
+    def test_change_attribute_value_2(self):
         """Check changing an attribute value on some variant of a template.
 
         Changing the value white to pink on variant 3 and 4.
@@ -125,3 +125,49 @@ class TestProductVariantChangeAttributeValue(common.SavepointCase):
             self._is_attribute_value_on_template(self.variant_1, self.white)
         )
         self.assertTrue(self.is_value_on_variant(self.variant_1, self.white))
+
+    def test_active_deactivate_attribute_value_2_step(self):
+        """ Deactivate a pav and reactivate it in 2 steps.
+
+        Use the wizard to desactivate (not used anymore) the white attribute
+        And reactivate it by using it on another variant.
+
+        """
+        self.assertTrue(
+            self._is_attribute_value_on_template(self.variant_1, self.white)
+        )
+        self.assertTrue(
+            self._is_attribute_value_on_template(self.variant_1, self.black)
+        )
+        wiz = self.wizard.with_context(default_res_ids=self.variants).create({})
+        self._change_action(wiz, self.white, "replace", self.pink)
+        wiz.action_change_attributes()
+        self.assertFalse(
+            self._is_attribute_value_on_template(self.variant_1, self.white)
+        )
+        self._change_action(wiz, self.black, "replace", self.white)
+        wiz.action_change_attributes()
+        self.assertTrue(
+            self._is_attribute_value_on_template(self.variant_1, self.white)
+        )
+        self.assertFalse(
+            self._is_attribute_value_on_template(self.variant_1, self.black)
+        )
+
+    def test_active_deactivate_attribute_value_1_step(self):
+        """ Deactivate a pav and reactivate it in 1 steps.
+
+        Same than previous tests but both replacement are done in one 
+        execution of the wizard.
+
+        """
+        wiz = self.wizard.with_context(default_res_ids=self.variants).create({})
+        self._change_action(wiz, self.white, "replace", self.pink)
+        self._change_action(wiz, self.black, "replace", self.white)
+        wiz.action_change_attributes()
+        self.assertTrue(
+            self._is_attribute_value_on_template(self.variant_1, self.white)
+        )
+        self.assertFalse(
+            self._is_attribute_value_on_template(self.variant_1, self.black)
+        )

--- a/product_variant_change_attribute_value/wizards/__init__.py
+++ b/product_variant_change_attribute_value/wizards/__init__.py
@@ -1,0 +1,2 @@
+from . import product_variant_attribute_value_action
+from . import product_variant_attribute_value_wizard

--- a/product_variant_change_attribute_value/wizards/product_variant_attribute_value_action.py
+++ b/product_variant_change_attribute_value/wizards/product_variant_attribute_value_action.py
@@ -17,9 +17,7 @@ class ProductVariantAttributeValueAction(models.TransientModel):
 
     product_attribute_value_id = fields.Many2one("product.attribute.value",)
     attribute_action = fields.Selection(
-        selection="_get_attribute_action_list",
-        default="do_nothing",
-        required=True,
+        selection="_get_attribute_action_list", default="do_nothing", required=True,
     )
     attribute_id = fields.Many2one(
         "product.attribute",

--- a/product_variant_change_attribute_value/wizards/product_variant_attribute_value_action.py
+++ b/product_variant_change_attribute_value/wizards/product_variant_attribute_value_action.py
@@ -8,9 +8,16 @@ class ProductVariantAttributeValueAction(models.TransientModel):
     _name = "variant.attribute.value.action"
     _description = "Wizard action to do on variant attribute value"
 
+    def _get_attibute_action_list(self):
+        return [
+            ("delete", "Delete"),
+            ("replace", "Replace"),
+            ("do_nothing", "Do Nothing"),
+        ]
+
     product_attribute_value_id = fields.Many2one("product.attribute.value",)
     attribute_action = fields.Selection(
-        [("delete", "Delete"), ("replace", "Replace"), ("do_nothing", "Do Nothing")],
+        selection=lambda self: self._get_attibute_action_list(),
         default="do_nothing",
         required=True,
     )
@@ -22,7 +29,7 @@ class ProductVariantAttributeValueAction(models.TransientModel):
     selectable_attribute_value_ids = fields.Many2many(
         "product.attribute.value", compute="_compute_selectable_attribute_value_ids"
     )
-    replaced_by = fields.Many2one(
+    replaced_by_id = fields.Many2one(
         "product.attribute.value",
         string="Replace with",
         domain="[('id', 'in', selectable_attribute_value_ids)]",

--- a/product_variant_change_attribute_value/wizards/product_variant_attribute_value_action.py
+++ b/product_variant_change_attribute_value/wizards/product_variant_attribute_value_action.py
@@ -8,7 +8,7 @@ class ProductVariantAttributeValueAction(models.TransientModel):
     _name = "variant.attribute.value.action"
     _description = "Wizard action to do on variant attribute value"
 
-    def _get_attibute_action_list(self):
+    def _get_attribute_action_list(self):
         return [
             ("delete", "Delete"),
             ("replace", "Replace"),
@@ -17,7 +17,7 @@ class ProductVariantAttributeValueAction(models.TransientModel):
 
     product_attribute_value_id = fields.Many2one("product.attribute.value",)
     attribute_action = fields.Selection(
-        selection=lambda self: self._get_attibute_action_list(),
+        selection="_get_attribute_action_list",
         default="do_nothing",
         required=True,
     )

--- a/product_variant_change_attribute_value/wizards/product_variant_attribute_value_action.py
+++ b/product_variant_change_attribute_value/wizards/product_variant_attribute_value_action.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class ProductVariantAttributeValueAction(models.TransientModel):
+    _name = "variant.attribute.value.action"
+    _description = "Wizard action to do on variant attribute value"
+
+    product_attribute_value_id = fields.Many2one("product.attribute.value",)
+    attribute_action = fields.Selection(
+        [("delete", "Delete"), ("replace", "Replace"), ("do_nothing", "Do Nothing")],
+        default="do_nothing",
+        required=True,
+    )
+    attribute_id = fields.Many2one(
+        "product.attribute",
+        related="product_attribute_value_id.attribute_id",
+        readonly=True,
+    )
+    selectable_attribute_value_ids = fields.Many2many(
+        "product.attribute.value", compute="_compute_selectable_attribute_value_ids"
+    )
+    replaced_by = fields.Many2one(
+        "product.attribute.value",
+        string="Replace with",
+        domain="[('id', 'in', selectable_attribute_value_ids)]",
+    )
+
+    @api.depends("attribute_action")
+    def _compute_selectable_attribute_value_ids(self):
+        for rec in self:
+            attribute_ids = self.attribute_id.value_ids.ids
+            rec.selectable_attribute_value_ids = [(6, 0, attribute_ids)]

--- a/product_variant_change_attribute_value/wizards/product_variant_attribute_value_wizard.py
+++ b/product_variant_change_attribute_value/wizards/product_variant_attribute_value_wizard.py
@@ -1,0 +1,135 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class VariantAttributeValueWizard(models.TransientModel):
+    _name = "variant.attribute.value.wizard"
+    _description = "Wizard to change attriubtes on product variants"
+
+    product_ids = fields.Many2many(
+        "product.product", default=lambda self: self._default_product_id()
+    )
+
+    attributes_action_ids = fields.Many2many(
+        "variant.attribute.value.action",
+        relation="rrhha_rel",
+        default=lambda self: self._default_attributes_action_ids(),
+    )
+
+    def _default_product_id(self):
+        return self.env["product.product"].browse(self._context.get("default_res_ids"))
+
+    def _default_attributes_action_ids(self):
+        p = self.env["product.product"].browse(self._context.get("default_res_ids"))
+        links = p.product_template_attribute_value_ids
+        attribute_ids = links.product_attribute_value_id
+        return [
+            (
+                0,
+                0,
+                {
+                    "product_attribute_value_id": x.id,
+                    "attribute_id": x.attribute_id,
+                    "attribute_action": "do_nothing",
+                },
+            )
+            for x in attribute_ids
+        ]
+
+    def action_change_attributes(self):
+        for product in self.product_ids:
+            self.update_variant_value(product)
+
+    def _is_attribute_value_being_used(self, variant_id, attribute_value):
+        """Check if attribute value is still in used on any variant of a template."""
+        existing_variants = self.env["product.product"].search(
+            [
+                ("id", "!=", variant_id.id),
+                ("product_tmpl_id", "=", variant_id.product_tmpl_id.id),
+            ],
+        )
+        existing_attributes = existing_variants.mapped(
+            "product_template_attribute_value_ids.product_attribute_value_id"
+        )
+        return attribute_value in existing_attributes
+
+    def update_variant_value(self, product_id):
+        """Update a variant with all the actions set by the user in the wizard."""
+        TplAttrLine = self.env["product.template.attribute.line"]
+        TplAttrValue = self.env["product.template.attribute.value"]
+        template = product_id.product_tmpl_id
+        pav_ids = product_id.product_template_attribute_value_ids.mapped(
+            "product_attribute_value_id"
+        )
+        for value_action in self.attributes_action_ids:
+            action = value_action.attribute_action
+            if action == "do_nothing":
+                continue
+            pav = value_action.product_attribute_value_id
+            if pav not in pav_ids:
+                continue
+            pav_replacement = value_action.replaced_by
+            if action == "replace" and not pav_replacement:
+                continue
+            elif action == "delete":
+                pass
+            elif action == "replace" and pav_replacement:
+                # Find corresponding attribute line on template or create it
+                attr = pav_replacement.attribute_id
+                tpl_attr_line = template.attribute_line_ids.filtered(
+                    lambda l: l.attribute_id == attr
+                )
+                if not tpl_attr_line:
+                    tpl_attr_line = TplAttrLine.create(
+                        {
+                            "product_tmpl_id": template.id,
+                            "attribute_id": attr.id,
+                            "value_ids": [(6, False, [pav_replacement.id])],
+                        }
+                    )
+                # Ensure the value exists in this attribute line.
+                # The context key 'update_product_template_attribute_values' avoids
+                # to create/unlink variants when values are updated on the template
+                # attribute line.
+                tpl_attr_line.with_context(
+                    update_product_template_attribute_values=False
+                ).write({"value_ids": [(4, pav_replacement.id)]})
+                # Get (or create if needed) the 'product.template.attribute.value'
+                tpl_attr_value = TplAttrValue.search(
+                    [
+                        ("attribute_line_id", "=", tpl_attr_line.id),
+                        ("product_attribute_value_id", "=", pav_replacement.id),
+                    ]
+                )
+                if not tpl_attr_value:
+                    tpl_attr_value = TplAttrValue.create(
+                        {
+                            "attribute_line_id": tpl_attr_line.id,
+                            "product_attribute_value_id": pav_replacement.id,
+                        }
+                    )
+            # Update the values set on the product variant
+            ptav_ids = product_id.product_template_attribute_value_ids.filtered(
+                lambda r: r.product_attribute_value_id != pav
+            )
+            if action == "replace":
+                ptav_ids |= tpl_attr_value
+            product_id.product_template_attribute_value_ids = ptav_ids
+            # Remove the changed value from the template attribute line if needed
+            if not self._is_attribute_value_being_used(product_id, pav):
+                tpl_attr_line = template.attribute_line_ids.filtered(
+                    lambda l: l.attribute_id == pav.attribute_id
+                )
+                tpl_attr_line.with_context(
+                    update_product_template_attribute_values=False
+                ).write({"value_ids": [(3, pav.id)]})
+                tpl_attr_value = TplAttrValue.search(
+                    [
+                        ("attribute_line_id", "=", tpl_attr_line.id),
+                        ("product_attribute_value_id", "=", pav.id),
+                    ]
+                )
+                if tpl_attr_value:
+                    tpl_attr_value.unlink()

--- a/product_variant_change_attribute_value/wizards/product_variant_attribute_value_wizard.xml
+++ b/product_variant_change_attribute_value/wizards/product_variant_attribute_value_wizard.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_product_variant_update_attribute_wizard" model="ir.ui.view">
+        <field name="name">Product Variant Update Attribute</field>
+        <field name="model">variant.attribute.value.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Product Variant Change Attribute">
+                <sheet>
+                    <!-- <div>Updating 8 variant(s) selected out of 2 product template.</div> -->
+                    <notebook>
+                        <page string="Attribute value changes">
+                            <group>
+                                <field name="attributes_action_ids" nolabel="1">
+                                    <tree
+                                        editable="true"
+                                        create="false"
+                                        delete="0"
+                                        open="0"
+                                    >
+                                        <field
+                                            name="attribute_action"
+                                            string="action"
+                                        />
+                                        <field name="product_attribute_value_id" />
+                                        <field
+                                            name="selectable_attribute_value_ids"
+                                            invisible="1"
+                                        />
+                                        <field
+                                            name="replaced_by"
+                                            attrs="{'readonly':[['attribute_action', '!=', 'replace' ]]}"
+                                        />
+                                    </tree>
+                                </field>
+                            </group>
+                        </page>
+                        <page string="Selected variants">
+                            <group>
+                                <field name="product_ids" nolabel="1">
+                                    <tree
+                                        edit="false"
+                                        create="false"
+                                        delete="false"
+                                        open="false"
+                                    >
+                                        <field name="default_code" />
+                                        <field name="name" />
+                                        <field
+                                            name="product_template_attribute_value_ids"
+                                            widget="many2many_tags"
+                                        />
+                                    </tree>
+                                </field>
+                            </group>
+                        </page>
+                    </notebook>
+                    <footer>
+                        <button
+                            name="action_change_attributes"
+                            string="Save"
+                            type="object"
+                            class="btn-primary"
+                        />
+                        <button
+                            string="Cancel"
+                            class="btn-secondary"
+                            special="cancel"
+                        />
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <act_window
+        id="action_variant_change_value"
+        name="Product Variant - Change attribute values assigned"
+        binding_model="product.product"
+        res_model="variant.attribute.value.wizard"
+        binding_views="list"
+        view_mode="form"
+        target="new"
+        context="{'default_res_ids': active_ids}"
+    />
+</odoo>

--- a/product_variant_change_attribute_value/wizards/product_variant_attribute_value_wizard.xml
+++ b/product_variant_change_attribute_value/wizards/product_variant_attribute_value_wizard.xml
@@ -7,10 +7,10 @@
             <form string="Product Variant Change Attribute">
                 <sheet>
                     <div>Updating <field
-                        name="product_variant_count"
-                    /> variant(s) selected out of <field
-                        name="product_template_count"
-                    /> product template(s).</div>
+                            name="product_variant_count"
+                        /> variant(s) selected out of <field
+                            name="product_template_count"
+                        /> product template(s).</div>
                     <notebook>
                         <page string="Attribute value changes">
                             <group>

--- a/product_variant_change_attribute_value/wizards/product_variant_attribute_value_wizard.xml
+++ b/product_variant_change_attribute_value/wizards/product_variant_attribute_value_wizard.xml
@@ -6,7 +6,11 @@
         <field name="arch" type="xml">
             <form string="Product Variant Change Attribute">
                 <sheet>
-                    <!-- <div>Updating 8 variant(s) selected out of 2 product template.</div> -->
+                    <div>Updating <field
+                        name="product_variant_count"
+                    /> variant(s) selected out of <field
+                        name="product_template_count"
+                    /> product template(s).</div>
                     <notebook>
                         <page string="Attribute value changes">
                             <group>
@@ -27,7 +31,7 @@
                                             invisible="1"
                                         />
                                         <field
-                                            name="replaced_by"
+                                            name="replaced_by_id"
                                             attrs="{'readonly':[['attribute_action', '!=', 'replace' ]]}"
                                         />
                                     </tree>
@@ -73,7 +77,7 @@
     </record>
     <act_window
         id="action_variant_change_value"
-        name="Product Variant - Change attribute values assigned"
+        name="Change attribute values assigned"
         binding_model="product.product"
         res_model="variant.attribute.value.wizard"
         binding_views="list"

--- a/setup/product_variant_change_attribute_value/odoo/addons/product_variant_change_attribute_value
+++ b/setup/product_variant_change_attribute_value/odoo/addons/product_variant_change_attribute_value
@@ -1,0 +1,1 @@
+../../../../product_variant_change_attribute_value

--- a/setup/product_variant_change_attribute_value/setup.py
+++ b/setup/product_variant_change_attribute_value/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Same PR than https://github.com/OCA/product-variant/pull/215 but based on an older commit (ping @TDu).

With standard Odoo there is no way to change the attribute values assigned
to a product variant.

This module adds a wizard that can be access through the product variant
tree view context action menu.

The wizard allows to change or remove attribute values on all product
variant selected.

When an attribute value is removed from all variant of a template,
it will also be removed from the configuration of the related product template.

Ref. 2090