### PR TITLE
[14.0][IMP] product_variant_default_code: prefix_code as default_code by default

### DIFF
--- a/product_variant_default_code/models/config_settings.py
+++ b/product_variant_default_code/models/config_settings.py
@@ -17,3 +17,9 @@ class BaseConfiguration(models.TransientModel):
         implied_group="product_variant_default_code"
         ".group_product_default_code_manual_mask",
     )
+
+    prefix_as_default_code = fields.Boolean(
+        string="Reference Prefix as default Reference",
+        default=False,
+        config_parameter="product_variant_default_code.prefix_as_default_code",
+    )

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -170,6 +170,18 @@ class ProductTemplate(models.Model):
             # to return the language code of your choice
             return self.env["res.lang"].search([], limit=1).code
 
+    @api.depends(
+        "product_variant_ids", "product_variant_ids.default_code", "code_prefix"
+    )
+    def _compute_default_code(self):
+        super()._compute_default_code()
+        if self.env["ir.config_parameter"].get_param("prefix_as_default_code"):
+            unique_variants = self.filtered(
+                lambda template: len(template.product_variant_ids) == 1
+            )
+            for template in self - unique_variants:
+                template.default_code = template.code_prefix
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -211,3 +211,9 @@ class TestVariantDefaultCode(common.SavepointCase):
         self.assertTrue("o_o" in self.template1.product_variant_ids[0].default_code)
         self.attr1_1.code = "^_^"
         self.assertTrue("^_^" in self.template1.product_variant_ids[0].default_code)
+
+    def test_11_prefix_code_as_default_code_by_default(self):
+        self.assertFalse(self.template1.default_code)
+        self.env["ir.config_parameter"].set_param("prefix_as_default_code", True)
+        self.template1.code_prefix = "prefix_code"
+        self.assertTrue(self.template1.default_code, self.template1.code_prefix)

--- a/product_variant_default_code/views/config_settings_view.xml
+++ b/product_variant_default_code/views/config_settings_view.xml
@@ -20,6 +20,17 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="prefix_as_default_code" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="prefix_as_default_code" />
+                            <div class="text-muted">
+                                Defines the variant "Reference Prefix" as the default reference (default_code) of the variant.
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
By default, when a product have variants, its default_code is False. No default_code can be disturbing in some products' views.
Here, we change it by putting the prefix_code as default_code by default. 

The change result in view :
![Capture d’écran de 2021-09-13 19-53-34](https://user-images.githubusercontent.com/75080572/133133271-bc25a437-6ca4-4be2-b971-ade68a716a5e.png)
![Capture d’écran de 2021-09-13 19-52-50](https://user-images.githubusercontent.com/75080572/133133297-3aec58bd-8681-496d-8a26-5f05e2337231.png)
