### PR TITLE
[14.0][FIX] product_variant_default_code : reference_mask and default_code not updated

### DIFF
--- a/product_variant_default_code/__manifest__.py
+++ b/product_variant_default_code/__manifest__.py
@@ -14,6 +14,7 @@
     "website": "https://github.com/OCA/product-variant",
     "license": "AGPL-3",
     "category": "Product",
+    "maintainers": ["Kev-Roche"],
     "depends": ["product"],
     "data": [
         "security/product_security.xml",

--- a/product_variant_default_code/__manifest__.py
+++ b/product_variant_default_code/__manifest__.py
@@ -5,11 +5,12 @@
 # Copyright 2017 Akretion - David Beal
 # Copyright 2018 AvancOSC - Daniel Campos
 # Copyright 2020 Tecnativa - João Marques
+# Copyright 2021 Akretion - Kévin Roche
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Product Variant Default Code",
     "version": "14.0.2.0.0",
-    "author": "AvancOSC, Shine IT, Tecnativa, Odoo Community Association (OCA)",
+    "author": "AvancOSC, Shine IT, Tecnativa, Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-variant",
     "license": "AGPL-3",
     "category": "Product",

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -119,8 +119,10 @@ class ProductTemplate(models.Model):
     def _compute_reference_mask(self):
         automask = self.is_automask()
         for rec in self:
-            if automask or rec.reference_mask == "":
+            if automask or not rec.reference_mask:
                 rec.reference_mask = rec._get_default_mask()
+            elif not automask and rec.code_prefix:
+                rec.reference_mask = rec.code_prefix + rec.reference_mask
 
     def _inverse_reference_mask(self):
         self._compute_reference_mask()

--- a/product_variant_default_code/readme/CONTRIBUTORS.rst
+++ b/product_variant_default_code/readme/CONTRIBUTORS.rst
@@ -2,6 +2,7 @@
 * Tony Gu <tony@openerp.cn>
 * David Beal <david.beal@akretion.com>
 * Daniel Campos <danielcampos@avanzosc.es>
+* Kévin Roche <kevin.roche@akretion.com>
 
 * Tecnativa <tecnativa.com>:
   * David Vidal

--- a/product_variant_default_code/views/product_attribute_view.xml
+++ b/product_variant_default_code/views/product_attribute_view.xml
@@ -14,15 +14,6 @@
             </field>
         </field>
     </record>
-    <record id="attribute_form_view_code" model="ir.ui.view">
-        <field name="model">product.attribute</field>
-        <field name="inherit_id" ref="product.product_attribute_view_form" />
-        <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="code" />
-            </field>
-        </field>
-    </record>
     <record id="view_product_attribute_search" model="ir.ui.view">
         <field name="model">product.attribute</field>
         <field name="arch" type="xml">

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -19,14 +19,12 @@
                 />
             </field>
             <xpath expr="//page/field[@name='attribute_line_ids']" position="before">
-                    <group>
                     <field
-                        name="variant_default_code_error"
-                        class="alert alert-danger alert-dismissable"
-                        role="alert"
-                        attrs="{'invisible':[('variant_default_code_error','=', False)]}"
-                    />
-                </group>
+                    name="variant_default_code_error"
+                    class="alert alert-danger alert-dismissable"
+                    role="alert"
+                    attrs="{'invisible':[('variant_default_code_error','=', False)]}"
+                />
             </xpath>
         </field>
     </record>

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -18,6 +18,16 @@
                     groups="product_variant_default_code.group_product_default_code_manual_mask"
                 />
             </field>
+            <xpath expr="//page/field[@name='attribute_line_ids']" position="before">
+                    <group>
+                    <field
+                        name="variant_default_code_error"
+                        class="alert alert-danger alert-dismissable"
+                        role="alert"
+                        attrs="{'invisible':[('variant_default_code_error','=', False)]}"
+                    />
+                </group>
+            </xpath>
         </field>
     </record>
     <record id="product_normal_form_view" model="ir.ui.view">


### PR DESCRIPTION
Some problems occur when using the variant default code. In the following cases (with corresponding tests), reference_mask (product.template) and default_code (variants/product.product) are not updated :
1) If the code_prefix changes : test_12_prefix_change
2) If we add a new variant attribute : test_13_new_attribute
3) If we rename a variant attribute : test_14_rename_attribute
4) If we change the variant attributes’ sequence : test_15_sequence_change