### PR TITLE
[13.0][FIX] product_variant_configurator: Drop attribute_id search on creation

### DIFF
--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -153,14 +153,6 @@ class ProductProduct(models.Model):
                             ],
                         ),
                         (
-                            "attribute_id",
-                            "in",
-                            [
-                                x[2]["attribute_id"]
-                                for x in vals["product_attribute_ids"]
-                            ],
-                        ),
-                        (
                             "product_attribute_value_id",
                             "in",
                             [

--- a/product_variant_configurator/models/product_template.py
+++ b/product_variant_configurator/models/product_template.py
@@ -98,3 +98,12 @@ class ProductTemplate(models.Model):
                 if limit and len(res) >= limit:
                     break
         return res
+
+    def _get_variant_for_combination(self, combination):
+        """
+        Overwrite method to allow attributes that no create variants be selectable
+        """
+        self.ensure_one()
+        return self.env["product.product"].browse(
+            self._get_variant_id_for_combination(combination)
+        )

--- a/product_variant_configurator/models/product_template_attribute_value.py
+++ b/product_variant_configurator/models/product_template_attribute_value.py
@@ -9,4 +9,4 @@ class ProductTemplateAttributeValue(models.Model):
     def _get_combination_name(self):
         """Overwritten method to avoid:
         Exclude values from single value lines or from no_variant attributes."""
-        return ", ".join([ptav.name for ptav in self._filter_single_value_lines()])
+        return ", ".join([ptav.name for ptav in self])


### PR DESCRIPTION
Steps to reproduce:
- Try to create a product variant manually from Product Variant.

Odoo fails because dict key "attribute_id" has disappeared

Traceback:
![image](https://user-images.githubusercontent.com/32061121/145539976-b96aed5b-d9ce-4971-9ca0-0b2b927e58c0.png)

CC @ForgeFlow 
