### PR TITLE
[13.0][product_variant_configurator] Drop attribute_id search on creation

### DIFF
--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -153,14 +153,6 @@ class ProductProduct(models.Model):
                             ],
                         ),
                         (
-                            "attribute_id",
-                            "in",
-                            [
-                                x[2]["attribute_id"]
-                                for x in vals["product_attribute_ids"]
-                            ],
-                        ),
-                        (
                             "product_attribute_value_id",
                             "in",
                             [


### PR DESCRIPTION
Replaces https://github.com/OCA/product-variant/pull/229

Steps to reproduce:

Try to create a product variant manually from Product Variant.

* Odoo fails because dict key "attribute_id" has disappeared

![image](https://user-images.githubusercontent.com/7683926/145895535-6d970a14-2fef-4004-92c0-020f6674fcc5.png)

@ForgeFlow