### PR TITLE
[13.0][MIG][FIX] product_variant_default_code: add a migration script

### DIFF
--- a/product_variant_default_code/migrations/13.0.1.1.0/pre-migration.py
+++ b/product_variant_default_code/migrations/13.0.1.1.0/pre-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Andrii Skrypka
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+xmlid_renames_res_groups = [
+    (
+        "product_variant_default_code.group_product_default_code",
+        "product_variant_default_code.group_product_default_code_manual_mask",
+    ),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_xmlids(env.cr, xmlid_renames_res_groups)


### PR DESCRIPTION
Not lose rights when migrating from Odoo 12 and avoid raising a constrain:
`The name of the group must be unique within an application!`