### PR TITLE
[13.0][IMP] product_variant_configurator - edit attributes values con variants

### DIFF
--- a/product_variant_configurator/readme/CONTRIBUTORS.rst
+++ b/product_variant_configurator/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
 * Simone Versienti <s.versienti@apuliasoftware.it>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
 * Héctor Villarreal Ortega <hector.villarreal@forgeflow.com>
+* Christopher Ormaza <chris.ormaza@forgeflow.com>

--- a/product_variant_configurator/security/product_configurator_security.xml
+++ b/product_variant_configurator/security/product_configurator_security.xml
@@ -6,4 +6,8 @@
         >Use extended description when having product attributes</field>
         <field name="category_id" ref="base.module_category_hidden" />
     </record>
+    <record id="group_product_variant_allow_edit_variants" model="res.groups">
+        <field name="name">Allow to edit attribute values in variants</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
 </odoo>

--- a/product_variant_configurator/views/inherited_product_product_views.xml
+++ b/product_variant_configurator/views/inherited_product_product_views.xml
@@ -45,7 +45,7 @@
                         <tree create="0" delete="0" editable="1">
                             <field name="owner_model" invisible="1" />
                             <field name="owner_id" invisible="1" />
-                            <field name="attribute_id" />
+                            <field name="attribute_id" force_save="1" />
                             <field
                                 name="possible_value_ids"
                                 widget="many2many_tags"
@@ -70,6 +70,83 @@
                         attrs="{'invisible': [('product_id', '=', False)]}"
                     />
                 </group>
+            </xpath>
+        </field>
+    </record>
+
+    <record
+        id="product_product_editable_attributes_easy_edit_form_view"
+        model="ir.ui.view"
+    >
+        <field
+            name="name"
+        >product.product.editable.attributes.easy.edit.form.view</field>
+        <field name="model">product.product</field>
+        <field name="priority">100</field>
+        <field
+            name="groups_id"
+            eval="[(4, ref('group_product_variant_allow_edit_variants'))]"
+        />
+        <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='product_template_attribute_value_ids']"
+                position="before"
+            >
+                <field name="attributes_editable" invisible="1" />
+                <field
+                    name="attributes_allowed_ids"
+                    invisible="1"
+                    widget="many2many_tags"
+                />
+            </xpath>
+            <xpath
+                expr="//field[@name='product_template_attribute_value_ids']"
+                position="attributes"
+            >
+                <attribute name="readonly">0</attribute>
+                <attribute
+                    name="attrs"
+                >{'readonly': ['|', ('attributes_editable', '=', False), ('id', '=', False)]}</attribute>
+                <attribute
+                    name="domain"
+                >[('id', 'in', attributes_allowed_ids)]</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="product_product_editable_attributes_form_view" model="ir.ui.view">
+        <field name="name">product.product.editable.attributes.form.view</field>
+        <field name="model">product.product</field>
+        <field name="priority">100</field>
+        <field
+            name="groups_id"
+            eval="[(4, ref('group_product_variant_allow_edit_variants'))]"
+        />
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='product_template_attribute_value_ids']"
+                position="before"
+            >
+                <field name="attributes_editable" invisible="1" />
+                <field
+                    name="attributes_allowed_ids"
+                    invisible="1"
+                    widget="many2many_tags"
+                />
+            </xpath>
+            <xpath
+                expr="//field[@name='product_template_attribute_value_ids']"
+                position="attributes"
+            >
+                <attribute name="readonly">0</attribute>
+                <attribute
+                    name="attrs"
+                >{'readonly': ['|', ('attributes_editable', '=', False), ('id', '=', False)]}</attribute>
+                <attribute
+                    name="domain"
+                >[('id', 'in', attributes_allowed_ids)]</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Added possibility to edit attributes values con variants, with specific permission, and template configured as No Create Templates
@ForgeFlow

Todo:

* [ ] Rename module to product_variant_configurator_editable_attribute


