### PR TITLE
[13.0][FIX] product_variant_configurator: Fix creation of incorrect records when no name is provided

### DIFF
--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -175,5 +175,7 @@ class ProductProduct(models.Model):
             )
             vals.pop("product_attribute_ids")
             vals["product_template_attribute_value_ids"] = [(4, x) for x in ptav]
-        obj = self.with_context(product_name=vals.get("name", ""))
+        obj = (
+            self.with_context(product_name=vals.get("name")) if "name" in vals else self
+        )
         return super(ProductProduct, obj).create(vals)


### PR DESCRIPTION
This should be addressing issue #239 