### PR TITLE
[13.0][FIX] product_variant_configurator: Error to create variant from template

### DIFF
--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -153,14 +153,6 @@ class ProductProduct(models.Model):
                             ],
                         ),
                         (
-                            "attribute_id",
-                            "in",
-                            [
-                                x[2]["attribute_id"]
-                                for x in vals["product_attribute_ids"]
-                            ],
-                        ),
-                        (
                             "product_attribute_value_id",
                             "in",
                             [

--- a/product_variant_configurator/readme/CONTRIBUTORS.rst
+++ b/product_variant_configurator/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
 * Simone Versienti <s.versienti@apuliasoftware.it>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
 * Héctor Villarreal Ortega <hector.villarreal@forgeflow.com>
+* Isaac Gallart <igallart@puntsistemes.es>


### PR DESCRIPTION
When you create a product template with attributes with option
"Variant creation: Don't create them automatically" and after
you create a product variant with the template previously created,
it fails (with values and without values):

File "/mnt/data/odoo-addons-dir/product_variant_configurator/models/product_product.py", line 160, in create
    for x in vals["product_attribute_ids"]
  File "/mnt/data/odoo-addons-dir/product_variant_configurator/models/product_product.py", line 160, in <listcomp>
    for x in vals["product_attribute_ids"]
KeyError: 'attribute_id'

I think that is not necessary add at the domain the value "attribute_id", an attribute_value is linked only a one attribute_id.


![Screenshot 2022-03-14 at 13-27-04 PRUEBA - Odoo](https://user-images.githubusercontent.com/13520529/158172170-8a0072fd-aba9-4734-84bd-43f498c8220b.png)
![Screenshot 2022-03-14 at 13-31-31 New - Odoo](https://user-images.githubusercontent.com/13520529/158172638-a7dc3ddd-4bc3-4d93-9ec9-7e04fe6fe034.png)
![Screenshot 2022-03-14 at 13-27-42 New - Odoo](https://user-images.githubusercontent.com/13520529/158172175-cf0db89a-c900-4e7c-8556-1f46623bb919.png)
![Screenshot 2022-03-14 at 13-27-52 New - Odoo](https://user-images.githubusercontent.com/13520529/158172176-abcfddff-6679-4322-8deb-872bd3fa6f30.png)
