### PR TITLE
[11.0][FIX] purchase_order_variant_mgmt: Add partner_id to load language

### DIFF
--- a/purchase_order_variant_mgmt/readme/CONTRIBUTORS.rst
+++ b/purchase_order_variant_mgmt/readme/CONTRIBUTORS.rst
@@ -6,3 +6,8 @@
 * `Comunitea <https://www.comunitea.com>`_:
 
   * Javier Colmenero <javier@comunitea.com>
+
+
+* `Punt Sistemes <https://www.puntsistemes.es>`_:
+
+  * Isaac Gallart <igallart@puntsistemes.es>

--- a/purchase_order_variant_mgmt/wizard/purchase_manage_variant.py
+++ b/purchase_order_variant_mgmt/wizard/purchase_manage_variant.py
@@ -86,6 +86,7 @@ class PurchaseManageVariant(models.TransientModel):
                     'product_uom': product.uom_id,
                     'product_uom_qty': line.product_uom_qty,
                     'order_id': purchase_order.id,
+                    'partner_id': purchase_order.partner_id.id,
                 })
                 order_line.onchange_product_id()
                 # This should be done later for handling supplier quantities


### PR DESCRIPTION
We pass the partner to the onchange_product_id method of
purchase_order_line to correctly load the product name when
it has translations.

If partner not is, in line
https://github.com/OCA/OCB/blob/700f30ab649eaf2b6c3f83adb405dc28704a2f83/addons/purchase/models/purchase.py#L827,
product_lang is False and after the translation in description field
is wrong.