### PR TITLE
[14.0][IMP] product_variant_inactive: Improved management of variants

### DIFF
--- a/product_variant_inactive/README.rst
+++ b/product_variant_inactive/README.rst
@@ -75,6 +75,7 @@ Contributors
 * Sebastien BEAU <sebastien.beau@akretion.com>
 * Abdessamad HILALI <abdessamad.hilali@akretion.com>
 * Kevin Khao <kevin.khao@akretion.com>
+* Chafique DELLI <chafique.delli@akretion.com>
 
 Maintainer
 ----------

--- a/product_variant_inactive/__manifest__.py
+++ b/product_variant_inactive/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "AGPL-3",
     "category": "Product",
     "version": "14.0.1.3.0",
-    "depends": ["stock"],
+    "depends": ["product"],
     "data": [
         "views/product_template_view.xml",
         "views/product_variant_view.xml",

--- a/product_variant_inactive/models/product_template.py
+++ b/product_variant_inactive/models/product_template.py
@@ -27,6 +27,7 @@ class ProductTemplate(models.Model):
     def _create_variant_ids(self):
         if "skip_reactivate_variant" not in self._context:
             self = self.with_context(skip_reactivate_variant=True)
+        self = self.with_context(unset_combination_deleted=True)
         return super()._create_variant_ids()
 
     @api.depends("product_variant_ids.active")

--- a/product_variant_inactive/tests/__init__.py
+++ b/product_variant_inactive/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import test_button
+from . import test_product_variant_inactive

--- a/product_variant_inactive/views/product_variant_view.xml
+++ b/product_variant_inactive/views/product_variant_view.xml
@@ -1,15 +1,4 @@
 <odoo>
-   <record model="ir.ui.view" id="view_stock_product_tree">
-        <field name="model">product.product</field>
-        <field name="inherit_id" ref="stock.view_stock_product_tree" />
-        <field name="arch" type="xml">
-            <!-- Add grey color for inactive record -->
-            <xpath expr="//tree" position="attributes">
-                <attribute name="decoration-muted">active==False</attribute>
-            </xpath>
-        </field>
-    </record>
-
 
     <record model="ir.ui.view" id="detail_field_custom_in_view">
         <field name="model">product.product</field>
@@ -20,12 +9,33 @@
                 <attribute name="widget">boolean_toggle</attribute>
                 <attribute name="optional">show</attribute>
             </xpath>
+            <!-- Add grey color for inactive record -->
+            <xpath expr="//tree" position="attributes">
+                <attribute name="decoration-muted">active==False</attribute>
+            </xpath>
         </field>
     </record>
+
     <record id="product.product_variant_action" model="ir.actions.act_window">
         <field name="context">{'search_default_product_tmpl_id': [active_id],
                                'default_product_tmpl_id': active_id,
                                'active_test': False}</field>
+        <field name="domain">[('combination_deleted', '!=', True)]</field>
+    </record>
+
+    <record id="product_search_form_view" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_search_form_view" />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator />
+                <filter
+                    string="Deleted combination"
+                    name="combination_deleted"
+                    domain="[('active', 'in', [False, True]),('combination_deleted', '=', True)]"
+                />
+            </filter>
+        </field>
     </record>
 
 </odoo>


### PR DESCRIPTION
- **Improvement of variants removal:** 
When you remove a variant feature then if the variant product has been used, Odoo will disable it and it will remain visible forever in the variants tab.
The idea is to flag these variants for deletion so that they are no longer seen

- **Improved performance when editing articles with many variants**:
Flag the variants whose combination has been deleted, we will no longer try to delete them when editing variants.

- Do not allow the reactivation of a variant whose combination has been deleted.
- Removal of the dependency on the Stock module
- Tests