### PR TITLE
[IMP][14.0] product tmpl default_code as default prefix_code

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -119,6 +119,8 @@ class ProductTemplate(models.Model):
     def _compute_reference_mask(self):
         automask = self.is_automask()
         for rec in self:
+            if rec.default_code and not rec.code_prefix:
+                rec.code_prefix = rec.default_code
             if automask or not rec.reference_mask:
                 rec.reference_mask = rec._get_default_mask()
             elif not automask and rec.code_prefix:


### PR DESCRIPTION
Sometimes, we indicate a default code on a product without variant. If we create variants, the default_code become invisible and can not be copy as prefix_code for variant. 
The present PR set the default_code of a single product (no variented) as defualt prefix_code. 