### PR TITLE
product_variant_inactive: fix unlink variant

### DIFF
--- a/product_variant_inactive/models/product_variant.py
+++ b/product_variant_inactive/models/product_variant.py
@@ -75,3 +75,8 @@ class ProductProduct(models.Model):
                         "combination has been deleted"
                     )
                 )
+
+    def unlink(self):
+        # Pass active_test = False to avoid deleting template
+        # with inactive variant
+        return super(ProductProduct, self.with_context(active_test=False)).unlink()

--- a/product_variant_inactive/tests/test_product_variant_inactive.py
+++ b/product_variant_inactive/tests/test_product_variant_inactive.py
@@ -69,8 +69,8 @@ class TestProductProduct(SavepointCase):
         self.assertEqual(self.template.product_variant_count, variant_count + 1)
         self.assertEqual(self.template.product_variant_count_all, variant_count_all)
 
-    def test_reactive_template(self):
-        template = self.env["product.template"].create(
+    def _create_template_with_variant(self):
+        return self.env["product.template"].create(
             {
                 "name": "FOO",
                 "attribute_line_ids": [
@@ -90,11 +90,21 @@ class TestProductProduct(SavepointCase):
                 ],
             }
         )
+
+    def test_reactive_template(self):
+        template = self._create_template_with_variant()
         variants = template.product_variant_ids
         template.write({"active": False})
         self.assertEqual(variants.mapped("active"), [False, False])
         template.write({"active": True})
         self.assertEqual(variants.mapped("active"), [True, True])
+
+    def test_unlink_variant_with_archive_template(self):
+        template = self._create_template_with_variant()
+        variant = template.product_variant_ids[0]
+        template.active = False
+        variant.unlink()
+        self.assertTrue(template.exists())
 
     def _deactivate_all_variants_of_template(self):
         self.template.product_variant_ids.write({"active": False})


### PR DESCRIPTION
When deleting a variant with other inactive variant, odoo is going to delete everything.
This can lead to unwanted deletation when using this module, so skip this behaviour, and only delete if there is really no existing variant.