### PR TITLE
[16.0] Revert "[FIX][product_variant_default_code] check code of active value_ids"

### DIFF
--- a/product_variant_default_code/__manifest__.py
+++ b/product_variant_default_code/__manifest__.py
@@ -15,7 +15,7 @@
     "license": "AGPL-3",
     "category": "Product",
     "maintainers": ["Kev-Roche"],
-    "depends": ["product_attribute_archive"],
+    "depends": ["product"],
     "data": [
         "security/product_security.xml",
         "data/ir_config_parameter.xml",

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -217,11 +217,7 @@ class ProductProduct(models.Model):
             rec.manual_code = bool(rec.default_code)
 
     def _generate_default_code(self):
-        value_codes = [
-            rec.code
-            for rec in self.product_tmpl_id.attribute_line_ids.value_ids
-            if rec.active
-        ]
+        value_codes = self.product_tmpl_id.attribute_line_ids.value_ids.mapped("code")
         if (not self.code_prefix and self.product_tmpl_id.is_automask()) or not all(
             value_codes
         ):


### PR DESCRIPTION
This reverts commit 20320aa0abc6ad7ef347d5e2a4b52010e45c4513.

This wild dependency has been introduced silently while the PR proposing it is not accepted and it's not a sane way to keep Odoo modularity. It this should be handled, it can be done putting a hook and a glue module, or searching for other solution.

@Tecnativa