### PR TITLE
[FIX] product_variant_default_code: code_prefix in reference_mask

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -123,7 +123,11 @@ class ProductTemplate(models.Model):
                 rec.code_prefix = rec.default_code
             if automask or not rec.reference_mask:
                 rec.reference_mask = rec._get_default_mask()
-            elif not automask and rec.code_prefix:
+            elif (
+                not automask
+                and rec.code_prefix
+                and rec.code_prefix not in rec.reference_mask
+            ):
                 rec.reference_mask = rec.code_prefix + rec.reference_mask
 
     def _inverse_reference_mask(self):


### PR DESCRIPTION
When `Reference Mask` is edited or `Code prefix` is erased, then the `Code prefix` gets duplicated in `Reference mask`. It can be tedious to work with so I add a condition that check if `Code prefix` is already on `Reference Mask`.


https://user-images.githubusercontent.com/100672471/236146919-c9ec9a12-4e1d-4c34-b443-3ac43d4c23f7.mp4
