### PR TITLE
[16.0][FIX] product_variant_default_code: fix template error

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -109,7 +109,7 @@ class ProductTemplate(models.Model):
                 )
             if error_txt:
                 error_txt = "Default Code can not be computed.\n" + error_txt
-            rec.variant_default_code_error = error_txt
+            rec.variant_default_code_error = error_txt or False
 
     @api.depends(
         "code_prefix",


### PR DESCRIPTION
When a product is being created or edited and attributes have not yet been added, a message is printed out in the band in case the reference prefix has not been filled in. If there is no error, this strip should remain hidden.

This error in the template has been detected and fixed in a migration to v15 (PR: https://github.com/OCA/product-variant/pull/291) and the same problem is being fixed in v14 and v16.

![image](https://user-images.githubusercontent.com/118818446/236631829-f4a22ee8-5168-44f5-8791-70a8228a2ab9.png)

cc @Tecnativa TT42976

@stefan-tecnativa  @chienandalu  please review :)