### PR TITLE
[FIX] Conditioning Unique variant and Current selection values use FIX #315

### DIFF
--- a/product_variant_configurator/models/product_configurator.py
+++ b/product_variant_configurator/models/product_configurator.py
@@ -97,8 +97,9 @@ class ProductConfigurator(models.AbstractModel):
             return {"domain": {"product_id": []}}
 
         if not self.product_tmpl_id.attribute_line_ids:
-            # template without attribute, use the unique variant
-            self.product_id = self.product_tmpl_id.product_variant_ids[0].id
+            # template without attribute, use the unique variant if exists (prevents from crashing on variant creation in the product variants menu)
+            if self.product_tmpl_id.product_variant_ids:
+                self.product_id = self.product_tmpl_id.product_variant_ids[0].id
         else:
             # verify the product correspond to the template
             # otherwise reset it
@@ -117,8 +118,11 @@ class ProductConfigurator(models.AbstractModel):
         else:
             self._empty_attributes()
 
-        # Restrict product possible values to current selection
-        domain = [("product_tmpl_id", "=", self.product_tmpl_id.ids[0])]
+        # Restrict product possible values to current selection if there is one (prevents from crashing on variant creation in the product variants menu)
+        if self.product_tmpl_id.ids:
+            domain = [("product_tmpl_id", "=", self.product_tmpl_id.ids[0])]
+        else:
+            domain = [("product_tmpl_id", "=", [])]
         return {"domain": {"product_id": domain}}
 
     @api.onchange("product_attribute_ids")


### PR DESCRIPTION
Product Variant Configurator seems to treat the Product Variant Creation Menu as a product template record, so its data goes through the execution flow as a supposed product template without attributes (tries to use the unique variant and tries to restrict product possible values to a non-existing selection).

This contribution prevents from using unique variants and values from the selection if they don't exist. It fixes #315  "Product Variant Creation menu not showing" issue without breaking the expected functionality.