### PR TITLE
[16.0][FIX] product_variant_name: pass on variant name to template when we create the new product variant

### DIFF
--- a/product_variant_name/models/product_product.py
+++ b/product_variant_name/models/product_product.py
@@ -2,10 +2,22 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
     name = fields.Char(index="trigram", required=True, translate=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        new_products = self.env["product.product"]
+        for vals in vals_list:
+            if "name" in vals:
+                new_products |= super(
+                    ProductProduct, self.with_context(template_name=vals["name"])
+                ).create([vals])
+                vals_list.remove(vals)
+        new_products |= super().create(vals_list)
+        return new_products

--- a/product_variant_name/models/product_template.py
+++ b/product_variant_name/models/product_template.py
@@ -2,11 +2,21 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import models
+from odoo import api, models
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if (
+                "template_name" in self._context
+                and "create_product_product" in self._context
+            ):
+                vals["name"] = self._context["template_name"]
+        return super().create(vals_list)
 
     def _prepare_variant_values(self, combination):
         variant_dict = super()._prepare_variant_values(combination)


### PR DESCRIPTION
The downside of this approach is that it will slow down the mass product creation as it calls to the product creation for each product individually.