### PR TITLE
[16.0][FIX] product_variant_configurator: Solve recursion error.

### DIFF
--- a/product_variant_configurator/models/__init__.py
+++ b/product_variant_configurator/models/__init__.py
@@ -6,3 +6,4 @@ from . import product_configurator_attribute
 from . import product_product
 from . import product_template
 from . import product_template_attribute_line
+from . import ir_ui_view

--- a/product_variant_configurator/models/ir_ui_view.py
+++ b/product_variant_configurator/models/ir_ui_view.py
@@ -1,0 +1,19 @@
+# Copyright 2023 ForgeFlow, S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3
+
+from odoo import models
+
+
+class View(models.Model):
+    _inherit = "ir.ui.view"
+
+    def _postprocess_tag_groupby(self, node, name_manager, node_info):
+        """Solves a recursion problem caused when the groupby refers to a
+        field of a many2one model, and that model also has the same field name.
+        In this example, the stock.valuation.layer.tree view contains a groupby
+        product_id, and the product.product model already has a product_id field,
+        relating to the same model. Without this code we would reach a recursion error."""
+        name = node.get("name")
+        if name_manager.model._name == "product.product" and name == "product_id":
+            return
+        return super()._postprocess_tag_groupby(node, name_manager, node_info)


### PR DESCRIPTION
This fix solves a recursion problem caused when the groupby refers to a field of a many2one model, and that model also has the same field name. In this example, the stock.valuation.layer.tree view contains a groupby product_id, and the product.product model already has a product_id field, relating to the same model. Without this code we would reach a recursion error.

Fixes https://github.com/OCA/product-variant/issues/330

cc @JordiMForgeFlow @marinaaforgeflow @lauracforgeflow @pedrobaeza 