### PR TITLE
[15.0][FIX] product_variant_default_code: recurrent prefix

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -124,7 +124,13 @@ class ProductTemplate(models.Model):
             if automask or not rec.reference_mask:
                 rec.reference_mask = rec._get_default_mask()
             elif not automask and rec.code_prefix:
-                rec.reference_mask = rec.code_prefix + rec.reference_mask
+                reference_mask = rec.reference_mask
+                # Avoid prefixing the mask twice (or more).
+                # TODO: This needs a better design with a third field that sums both
+                # or using the sum of them in the variant default code computation
+                if reference_mask.startswith(rec.code_prefix):
+                    reference_mask = reference_mask.lstrip(rec.code_prefix)
+                rec.reference_mask = rec.code_prefix + reference_mask
 
     def _inverse_reference_mask(self):
         self._compute_reference_mask()

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -368,17 +368,21 @@ class TestVariantDefaultCode(common.TransactionCase):
                 "reference_mask": "fix-[TColor]/[TSize]",
             }
         )
-
         for product in self.template1.mapped("product_variant_ids"):
-            expected_code = (
-                self.template1.code_prefix
-                + "fix-"
-                + product.product_template_attribute_value_ids.filtered(
-                    lambda x: x.product_attribute_value_id.attribute_id == self.attr2
-                ).name[0:2]
-                + "/"
-                + product.product_template_attribute_value_ids.filtered(
-                    lambda x: x.product_attribute_value_id.attribute_id == self.attr1
-                ).name[0:2]
-            )
-            self.assertEqual(product.default_code, expected_code)
+            attr1 = product.product_template_attribute_value_ids.filtered(
+                lambda x: x.product_attribute_value_id.attribute_id == self.attr2
+            ).name[0:2]
+            attr2 = product.product_template_attribute_value_ids.filtered(
+                lambda x: x.product_attribute_value_id.attribute_id == self.attr1
+            ).name[0:2]
+            self.assertEqual(product.default_code, f"pre/fix-{attr1}/{attr2}")
+        # The reference_mask stays the same even if recomputed
+        self.template1._compute_reference_mask()
+        for product in self.template1.mapped("product_variant_ids"):
+            attr1 = product.product_template_attribute_value_ids.filtered(
+                lambda x: x.product_attribute_value_id.attribute_id == self.attr2
+            ).name[0:2]
+            attr2 = product.product_template_attribute_value_ids.filtered(
+                lambda x: x.product_attribute_value_id.attribute_id == self.attr1
+            ).name[0:2]
+            self.assertEqual(product.default_code, f"pre/fix-{attr1}/{attr2}")


### PR DESCRIPTION
With a non automatic reference mask that has a code prefix, when that reference mask is recomputed, we could be repeating the prefix without noticing it. For instance, when we change an product.attribute name and that triggers all the default codes recomputations.

cc @Tecnativa TT48322

please review @pedrobaeza @victoralmau 