### PR TITLE
[16.0][FIX] product_variant_configurator: change instance checking

### DIFF
--- a/product_variant_configurator/models/pricelist.py
+++ b/product_variant_configurator/models/pricelist.py
@@ -13,7 +13,7 @@ class ProductPricelist(models.Model):
     def _compute_price_rule(self, products, qty, uom=None, date=False, **kwargs):
         """Overwrite for covering the case where templates are passed and a
         different uom is used."""
-        if products[0]._name != "product.template":
+        if products._name != "product.template":
             # Standard use case - Nothing to do
             return super(ProductPricelist, self)._compute_price_rule(
                 products,


### PR DESCRIPTION
Creating a new Sales Order and selecting a product in the SO line, and choosing any subscription period results in a technical error.

Checking instance (`_name`) should not be on a specific record, it could be done on all products. And if there is no products, getting to first record raises and `Index out of range` error.

This fixes `Index out of range` error.

