### PR TITLE
[11.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/product_variant_sale_order_route/__manifest__.py
+++ b/product_variant_sale_order_route/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Product Variant Sale Order Route',
     'version': '11.0.1.0.0',
     'category': 'Product',
-    'author': 'Camptocamp SA, '
+    'author': 'Camptocamp, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'depends': [

--- a/product_variant_specific_tax/__manifest__.py
+++ b/product_variant_specific_tax/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Product Variant Specific Tax',
     'version': '11.0.1.0.0',
     'category': 'Product',
-    'author': 'Camptocamp SA, '
+    'author': 'Camptocamp, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'depends': [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 11.0.