### PR TITLE
[13.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/product_attribute_value_archive/__manifest__.py
+++ b/product_attribute_value_archive/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "13.0.1.0.0",
     "category": "Product",
     "website": "https://github.com/OCA/product-variant",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["mmequignon"],
     "license": "AGPL-3",
     "installable": True,


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 13.0.