### PR TITLE
[FIX] product_variant_default_code: reference mask template

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -230,6 +230,8 @@ class ProductProduct(models.Model):
         else:
             product_attrs = defaultdict(str)
             reference_mask = ReferenceMask(self.product_tmpl_id.reference_mask)
+            if reference_mask.template is False:
+                reference_mask.template = ""
             main_lang = self.product_tmpl_id._guess_main_lang()
             for attr in self.product_template_attribute_value_ids:
                 value = attr.product_attribute_value_id


### PR DESCRIPTION

This fix is ​​to correct the error that occurs when using the "Loyalty" base module when using any suggested template. As you try to create a variant by code, it does not have a template and is output as "false" and the "safe_substitute" function needs a string or bytes. 

