### PR TITLE
[17.0][FIX] product_variant_sale_price: edit Sales Price

### DIFF
--- a/product_variant_sale_price/README.rst
+++ b/product_variant_sale_price/README.rst
@@ -70,6 +70,7 @@ Contributors
 -  RabbitJon-S73 <roger@studio73.es>
 -  Emanuel Cino <ecino@compassion.ch>
 -  Pedroguirao <pguirao@puntsistemes.es>
+-  Gabriel Grinspan <gabriel@rooteam.net>
 
 Maintainers
 -----------

--- a/product_variant_sale_price/readme/CONTRIBUTORS.md
+++ b/product_variant_sale_price/readme/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 - RabbitJon-S73 \<<roger@studio73.es>\>
 - Emanuel Cino \<<ecino@compassion.ch>\>
 - Pedroguirao \<<pguirao@puntsistemes.es>\>
+- Gabriel Grinspan \<<gabriel@rooteam.net>\>

--- a/product_variant_sale_price/static/description/index.html
+++ b/product_variant_sale_price/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -414,12 +415,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>RabbitJon-S73 &lt;<a class="reference external" href="mailto:roger&#64;studio73.es">roger&#64;studio73.es</a>&gt;</li>
 <li>Emanuel Cino &lt;<a class="reference external" href="mailto:ecino&#64;compassion.ch">ecino&#64;compassion.ch</a>&gt;</li>
 <li>Pedroguirao &lt;<a class="reference external" href="mailto:pguirao&#64;puntsistemes.es">pguirao&#64;puntsistemes.es</a>&gt;</li>
+<li>Gabriel Grinspan &lt;<a class="reference external" href="mailto:gabriel&#64;rooteam.net">gabriel&#64;rooteam.net</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_variant_sale_price/views/product_views.xml
+++ b/product_variant_sale_price/views/product_views.xml
@@ -23,7 +23,7 @@
         <field name="arch" type="xml">
             <!-- Make the field editable -->
             <field name="lst_price" position="attributes">
-                <attribute name="attrs" />
+                <attribute name="readonly" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
There is an issue in 17.0 where the Sales Price field is not editable in the quick view page found by navigating to variants from a parent product page. This module makes it such that the field is separated between products and variants. It should be easy to modify this field without having to navigate to the variants list page and search.

I believe this worked in previous versions, as the code seems to indicate there was a purpose for clearing `attrs` but in Odoo 17, Odoo removed that attribute and replaced it with options. As it is, options has nothing to do with `readonly` in this case.