### PR TITLE
[FIX] product_variant_configurator, product_variant_sale_price: manually bump versions

### DIFF
--- a/product_variant_configurator/__manifest__.py
+++ b/product_variant_configurator/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Product Variant Configurator",
     "summary": "Provides an abstract model for product variant configuration.",
-    "version": "16.0.1.0.5",
+    "version": "16.0.1.0.6",
     "category": "Product Variant",
     "development_status": "Production/Stable",
     "license": "AGPL-3",

--- a/product_variant_sale_price/__manifest__.py
+++ b/product_variant_sale_price/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Product Variant Sale Price",
     "summary": "Allows to write fixed prices in product variants",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "Product Management",
     "website": "https://github.com/OCA/product-variant",
     "author": "Tecnativa, " "Odoo Community Association (OCA)",


### PR DESCRIPTION
Changes have been merged with nobump in PR #353