### PR TITLE
[16.0][IMP] sale_variant_configurator: add create_product_variant to form

### DIFF
--- a/sale_variant_configurator/views/sale_view.xml
+++ b/sale_variant_configurator/views/sale_view.xml
@@ -57,6 +57,12 @@
                         <field name="price_extra" />
                     </tree>
                 </field>
+                <field name="can_create_product" invisible="1" />
+                <field
+                    name="create_product_variant"
+                    attrs="{'invisible':
+                    [('can_create_product', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
When you try to configure a variant that doesn't exist yet, there's no way to add it to the sale order. That's because we're missing the create_product_variant field to create it when needed.