### PR TITLE
[16.0][FIX] product_variant_default_code ir.config_parameter

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -186,7 +186,9 @@ class ProductTemplate(models.Model):
     )
     def _compute_default_code(self):
         super()._compute_default_code()
-        if self.env["ir.config_parameter"].get_param("prefix_as_default_code"):
+        if self.env["ir.config_parameter"].get_param(
+            "product_variant_default_code.prefix_as_default_code"
+        ):
             unique_variants = self.filtered(
                 lambda template: len(template.product_variant_ids) == 1
             )

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -229,7 +229,9 @@ class TestVariantDefaultCode(TransactionCase):
 
     def test_11_prefix_code_as_default_code_by_default(self):
         self.assertFalse(self.template1.default_code)
-        self.env["ir.config_parameter"].set_param("prefix_as_default_code", True)
+        self.env["ir.config_parameter"].set_param(
+            "product_variant_default_code.prefix_as_default_code", True
+        )
         self.template1.code_prefix = "prefix_code"
         self.assertTrue(self.template1.default_code, self.template1.code_prefix)
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/23eeb665-5dc2-4fcd-bba1-c5832caf8e81)

this setting is useless because module name is not considered

for now is has to be set manually on ir.config_parameter without prefix