### PR TITLE
[16.0][FIX] product_variant_configurator: Get all name_get values fro…

### DIFF
--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -136,7 +136,7 @@ class ProductProduct(models.Model):
             if isinstance(product.id, models.NewId):
                 res.append((product.id, product.name))
             else:
-                res.append(super(ProductProduct, product).name_get()[0])
+                res.extend(tuple(super(ProductProduct, product).name_get()))
         return res
 
     @api.model_create_multi


### PR DESCRIPTION
…m product

Fixes name_get to append ALL name_get values correctly (if more than 1). This happens when e.g. there are more than 1 products in product.supplierinfo and product is searched in purchase.order