### PR TITLE
[16.0][FIX] sale_variant_configurator: Do not create products for downpayments

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -90,7 +90,11 @@ class SaleOrderLine(models.Model):
         confirmed and a line is added.
         """
         for vals in vals_list:
-            if vals.get("order_id") and not vals.get("product_id"):
+            if (
+                vals.get("order_id")
+                and not vals.get("product_id")
+                and not vals.get("is_downpayment")
+            ):
                 order = self.env["sale.order"].browse(vals["order_id"])
                 if order.state == "sale":
                     line = self.new(vals)


### PR DESCRIPTION
Do not create products for downpayments

**Before**:
![antes](https://github.com/user-attachments/assets/5a78c984-257a-4e25-b88e-38eb19bb6193)

**After**:
![despues](https://github.com/user-attachments/assets/58ebcafa-3c65-4f0d-ab4c-097d437ab07c)

@Tecnativa