### PR TITLE
[18.0][FIX] product_attribute_value_archive: Fix issue where attribute_id may not be set

### DIFF
--- a/product_attribute_value_archive/models/product_attribute_value.py
+++ b/product_attribute_value_archive/models/product_attribute_value.py
@@ -69,12 +69,16 @@ class ProductAttributeValue(models.Model):
         values_to_create = []
         unarchived_record_ids = set()
         for value in values:
+            attribute_id = value.get(
+                "attribute_id", self._context.get("default_attribute_id")
+            )
             existing_archived_value = self.search(
                 [
                     ("active", "=", False),
                     ("name", "=", value["name"]),
-                    ("attribute_id", "=", value["attribute_id"]),
-                ]
+                    ("attribute_id", "=", attribute_id),
+                ],
+                limit=1,
             )
             if existing_archived_value:
                 existing_archived_value.active = True


### PR DESCRIPTION
ISSUE: In case product.attribute.value is created directly from the product form view, values parameter in create method doesn't contain attribute_id.
This PR resolves this issue

![image](https://github.com/user-attachments/assets/8d75df02-51d2-49c9-8f91-0b903b662380)
