### PR TITLE
[15.0][IMP]product_variant_configurator_manual_creation: has pending variants compute performance

### DIFF
--- a/product_variant_configurator_manual_creation/README.rst
+++ b/product_variant_configurator_manual_creation/README.rst
@@ -70,6 +70,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Christopher Ormaza <chris.ormaza@forgeflow.com>
+* Manuel Regidor <manuel.regidor@sygel.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_variant_configurator_manual_creation/models/product_template.py
+++ b/product_variant_configurator_manual_creation/models/product_template.py
@@ -14,6 +14,44 @@ class ProductTemplate(models.Model):
         compute="_compute_pending_variants",
     )
 
+    def _get_all_variant_combinations(self):
+        lines_without_no_variants = (
+            self.valid_product_template_attribute_line_ids._without_no_variant_attributes()
+        )
+        return itertools.product(
+            *[
+                ptal.product_template_value_ids._only_active()
+                for ptal in lines_without_no_variants
+            ]
+        )
+
+    def _get_existing_variants(self):
+        all_variants = self.product_variant_ids.sorted(
+            lambda p: (p.active, p.id and -p.id or False)
+        )
+        return {
+            variant.product_template_attribute_value_ids: variant
+            for variant in all_variants
+        }
+
+    @api.model
+    def _get_variant_combination(self, combination_tuple):
+        combination = self.env["product.template.attribute.value"].concat(
+            *combination_tuple
+        )
+        if not self._is_combination_possible_by_config(
+            combination, ignore_no_variant=True
+        ):
+            combination = False
+        return combination
+
+    @api.model
+    def _can_add_variant(self, value):
+        return not (
+            isinstance(value.attribute_id.id, models.NewId)
+            or isinstance(value.product_attribute_value_id.id, models.NewId)
+        )
+
     @api.depends(
         "product_variant_ids",
         "attribute_line_ids",
@@ -22,49 +60,37 @@ class ProductTemplate(models.Model):
     )
     def _compute_pending_variants(self):
         for rec in self:
-            rec.has_pending_variants = bool(self._get_values_without_variant())
+            has_pending_variants = False
+            all_combinations = self._get_all_variant_combinations()
+            existing_variants = self._get_existing_variants()
+            for combination_tuple in all_combinations:
+                combination = self._get_variant_combination(combination_tuple)
+                if combination and combination not in existing_variants:
+                    for value in combination:
+                        if self._can_add_variant(value):
+                            has_pending_variants = True
+                            break
+                if has_pending_variants:
+                    break
+            rec.has_pending_variants = has_pending_variants
 
     def _get_values_without_variant(self):
-        lines_without_no_variants = (
-            self.valid_product_template_attribute_line_ids._without_no_variant_attributes()
-        )
-        all_variants = self.product_variant_ids.sorted(
-            lambda p: (p.active, p.id and -p.id or False)
-        )
-        all_combinations = itertools.product(
-            *[
-                ptal.product_template_value_ids._only_active()
-                for ptal in lines_without_no_variants
-            ]
-        )
-        existing_variants = {
-            variant.product_template_attribute_value_ids: variant
-            for variant in all_variants
-        }
+        all_combinations = self._get_all_variant_combinations()
+        existing_variants = self._get_existing_variants()
         values_without_variant = {}
         for combination_tuple in all_combinations:
-            combination = self.env["product.template.attribute.value"].concat(
-                *combination_tuple
-            )
-            is_combination_possible = self._is_combination_possible_by_config(
-                combination, ignore_no_variant=True
-            )
-            if not is_combination_possible:
-                continue
-            if combination not in existing_variants:
+            combination = self._get_variant_combination(combination_tuple)
+            if combination and combination not in existing_variants:
                 for value in combination:
-                    if isinstance(value.attribute_id.id, models.NewId) or isinstance(
-                        value.product_attribute_value_id.id, models.NewId
-                    ):
-                        continue
-                    values_without_variant.setdefault(
-                        value.attribute_id.id,
-                        {
-                            "required": value.attribute_line_id.required,
-                            "value_ids": [],
-                        },
-                    )
-                    values_without_variant[value.attribute_id.id]["value_ids"].append(
-                        value.product_attribute_value_id.id
-                    )
+                    if self._can_add_variant(value):
+                        values_without_variant.setdefault(
+                            value.attribute_id.id,
+                            {
+                                "required": value.attribute_line_id.required,
+                                "value_ids": [],
+                            },
+                        )
+                        values_without_variant[value.attribute_id.id][
+                            "value_ids"
+                        ].append(value.product_attribute_value_id.id)
         return values_without_variant

--- a/product_variant_configurator_manual_creation/readme/CONTRIBUTORS.rst
+++ b/product_variant_configurator_manual_creation/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Christopher Ormaza <chris.ormaza@forgeflow.com>
+* Manuel Regidor <manuel.regidor@sygel.es>

--- a/product_variant_configurator_manual_creation/static/description/index.html
+++ b/product_variant_configurator_manual_creation/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -414,12 +414,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
 <li>Christopher Ormaza &lt;<a class="reference external" href="mailto:chris.ormaza&#64;forgeflow.com">chris.ormaza&#64;forgeflow.com</a>&gt;</li>
+<li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_variant_configurator_manual_creation/tests/test_product_variant_configurator_manual_creation.py
+++ b/product_variant_configurator_manual_creation/tests/test_product_variant_configurator_manual_creation.py
@@ -48,6 +48,7 @@ class TestProductVariantConfiguratorManualCreation(TransactionCase):
             variants.product_template_attribute_value_ids.product_attribute_value_id.id,
             False,
         )
+        self.assertTrue(self.product_template1.has_pending_variants)
         variant_creation_wizard1 = self.wizard_variant_manual_creation.with_context(
             active_id=self.product_template1.id
         ).create({})
@@ -88,3 +89,4 @@ class TestProductVariantConfiguratorManualCreation(TransactionCase):
             variants.product_template_attribute_value_ids.product_attribute_value_id.ids,
             [self.value1.id, self.value2.id],
         )
+        self.assertFalse(self.product_template1.has_pending_variants)


### PR DESCRIPTION
Before this imp, the has_pending_variants field in product.template was computed using the same method used to identify all the pending product variants. That is not very efficient, as the has_pending_variants field can be set to True as soon as one pending product variant is found, so there ir no need  to get all the pending variant options.

T-8340