### PR TITLE
[17.0][FIX] product_variant_sale_price: remove deprecated arg

### DIFF
--- a/product_variant_sale_price/__manifest__.py
+++ b/product_variant_sale_price/__manifest__.py
@@ -8,7 +8,7 @@
     "version": "17.0.1.1.0",
     "category": "Product Management",
     "website": "https://github.com/OCA/product-variant",
-    "author": "Tecnativa, " "Odoo Community Association (OCA)",
+    "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
     "depends": ["account", "sale"],

--- a/product_variant_sale_price/models/product_product.py
+++ b/product_variant_sale_price/models/product_product.py
@@ -32,7 +32,6 @@ class ProductTemplate(models.Model):
         combination=False,
         product_id=False,
         add_qty=1,
-        pricelist=False,
         parent_combination=False,
         only_template=False,
     ):
@@ -40,7 +39,6 @@ class ProductTemplate(models.Model):
             combination,
             product_id,
             add_qty,
-            pricelist,
             parent_combination,
             only_template,
         )

--- a/product_variant_sale_price/readme/CONTRIBUTORS.md
+++ b/product_variant_sale_price/readme/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 - Emanuel Cino \<<ecino@compassion.ch>\>
 - Pedroguirao \<<pguirao@puntsistemes.es>\>
 - Gabriel Grinspan \<<gabriel@rooteam.net>\>
+- Cédric Paradis \<<cparadis@impressfoods.com>\>


### PR DESCRIPTION
product_variant_sale_price: remove deprecated arg from _get_combination_info
See #370 and https://github.com/odoo/odoo/commit/4069158c96bbf2a6357622d5c0b0a91d722dd4cb#diff-acd257cca7239231cc665a67eb891818ecfa7d0643d923d74099742e61b9ee68L91