### PR TITLE
[17.0][FIX] purchase_variant_configurator: _select_seller signature

### DIFF
--- a/purchase_variant_configurator/models/product_product.py
+++ b/purchase_variant_configurator/models/product_product.py
@@ -10,7 +10,13 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     def _select_seller(
-        self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False
+        self,
+        partner_id=False,
+        quantity=0.0,
+        date=None,
+        uom_id=False,
+        ordered_by="price_discounted",
+        params=False,
     ):
         """Don't fail on empty products for allowing to copy purchase order lines."""
         if not self:
@@ -20,5 +26,6 @@ class ProductProduct(models.Model):
             quantity=quantity,
             date=date,
             uom_id=uom_id,
+            ordered_by=ordered_by,
             params=params,
         )


### PR DESCRIPTION
The signature of the method is not correct according upstream:

https://github.com/odoo/odoo/blob/8eddce363f05cc672c0c208239f86254f1175da1/addons/product/models/product_product.py#L682

so we should stick to the proper one.

@Tecnativa