### PR TITLE
[16.0][FIX] product_variant_default_code: avoid unnecessary writes

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -217,7 +217,11 @@ class ProductProduct(models.Model):
         self.env.cr.flush()  # https://github.com/odoo/odoo/blob/16.0/odoo/models.py#L5592
         for rec in self:
             if not rec.manual_code:
-                rec.default_code = rec._generate_default_code()
+                new_code = rec._generate_default_code()
+                # Only write if the value actually changed to avoid unnecessary
+                # write_date updates that can cause PostgreSQL serialization errors
+                if rec.default_code != new_code:
+                    rec.default_code = new_code
 
     def _inverse_default_code(self):
         for rec in self:
@@ -225,8 +229,10 @@ class ProductProduct(models.Model):
 
     def _generate_default_code(self):
         value_codes = self.product_tmpl_id.attribute_line_ids.value_ids.mapped("code")
-        if (not self.code_prefix and self.product_tmpl_id.is_automask()) or not all(
-            value_codes
+        if (
+            (not self.code_prefix and self.product_tmpl_id.is_automask())
+            or not all(value_codes)
+            or not self.product_tmpl_id.reference_mask
         ):
             return None
         else:


### PR DESCRIPTION
## Description

Optimizes the default_code computation in product variants:

1. **Avoid unnecessary writes**: Only writes to default_code when the value actually changes. in db with many products makes upgrades faster

2. **Early return without reference_mask**: Returns None early in `_generate_default_code()` when no reference_mask is defined, avoiding unnecessary processing, that was causing error during upgrades when database already contain many products and no automask setting is on

## Testing

- Tested in production environment with concurrent product updates
- No more serialization errors when multiple users edit products simultaneously

## Checklist

- [x] Fixes a bug
- [x] Code follows OCA guidelines
- [x] Tests pass