### PR TITLE
[18.0][FIX] product_variant_sale_price: fix double UoM calculations

### DIFF
--- a/product_variant_sale_price/models/product_product.py
+++ b/product_variant_sale_price/models/product_product.py
@@ -28,13 +28,8 @@ class ProductProduct(models.Model):
             product.lst_price = price
 
     def _compute_list_price(self):
-        uom_model = self.env["uom.uom"]
         for product in self:
-            price = product.fix_price or product.product_tmpl_id.list_price
-            if self.env.context.get("uom"):
-                context_uom = uom_model.browse(self.env.context["uom"])
-                price = product.uom_id._compute_price(price, context_uom)
-            product.list_price = price
+            product.list_price = product.fix_price or product.product_tmpl_id.list_price
 
     def _inverse_product_lst_price(self):
         uom_model = self.env["uom.uom"]


### PR DESCRIPTION
Fix issue where changing the quantity on a sales order line after the UoM had been changed resulted in a double UoM conversion. To re-produce:
1. Create a new sales order and add a line item with, for example, Gal as the UoM
2. Change the UoM to Quart
3. Attempt to update the quantity. The price will be double UoM converted, thus causing the it to drop drastically from the correct price.

The last time this code was touched was 9 years ago. I believe Odoo since added this as a standard feature.