### PR TITLE
[16.0][FIX] product_variant_configurator: prevent newId wrapping of existing template on new variants

### DIFF
--- a/product_variant_configurator/__init__.py
+++ b/product_variant_configurator/__init__.py
@@ -1,1 +1,2 @@
+from . import hooks
 from . import models

--- a/product_variant_configurator/hooks.py
+++ b/product_variant_configurator/hooks.py
@@ -1,0 +1,42 @@
+# Copyright 2026 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields
+from odoo.models import NewId
+
+
+def _patch_many2one_no_wrap_existing_parent():
+    """Patch ``Many2one.convert_to_cache`` so that linking a new child
+    record to an existing parent through a delegate (``_inherits``) field
+    keeps the parent's real id instead of wrapping it in :class:`NewId`.
+
+    The standard Odoo behaviour wraps the parent id whenever the child
+    record is new, on the assumption that the parent is being created
+    together with the child.  That fits Odoo's native flow (a new
+    variant auto-created alongside a new template) but breaks the
+    variant configurator's flow where a new variant is attached to an
+    *existing* template: the wrap then makes
+    ``Field._compute_company_dependent`` reads on the parent return
+    empty, because its result dict is keyed by real ids while the loop
+    uses the record's ``NewId`` as the lookup key.
+    """
+    if getattr(fields.Many2one, "_no_wrap_existing_parent_patched", False):
+        return
+    _original_convert_to_cache = fields.Many2one.convert_to_cache
+
+    def convert_to_cache(self, value, record, validate=True):
+        if (
+            self.delegate
+            and record
+            and not any(record._ids)
+            and isinstance(value, int)
+            and not isinstance(value, NewId)
+            and value > 0
+        ):
+            return value
+        return _original_convert_to_cache(self, value, record, validate)
+
+    fields.Many2one.convert_to_cache = convert_to_cache
+    fields.Many2one._no_wrap_existing_parent_patched = True
+
+
+_patch_many2one_no_wrap_existing_parent()

--- a/product_variant_configurator/tests/__init__.py
+++ b/product_variant_configurator/tests/__init__.py
@@ -1,4 +1,6 @@
+from . import fake_models  # noqa: F401
 from . import test_product_variant_configurator
 from . import test_product_configurator_attribute
 from . import test_product_pricelist
 from . import test_product_variants
+from . import test_company_dependent_inherited

--- a/product_variant_configurator/tests/fake_models.py
+++ b/product_variant_configurator/tests/fake_models.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    # Test-only company_dependent field
+    _inherit = "product.template"  # pylint: disable=consider-merging-classes-inherited
+
+    x_test_cd_partner = fields.Many2one(
+        comodel_name="res.partner",
+        string="Test CD Partner",
+        company_dependent=True,
+    )

--- a/product_variant_configurator/tests/test_company_dependent_inherited.py
+++ b/product_variant_configurator/tests/test_company_dependent_inherited.py
@@ -1,0 +1,50 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+from .fake_models import ProductTemplate as _TestProductTemplate
+
+
+@tagged("post_install", "-at_install")
+class TestCompanyDependentInherited(TransactionCase):
+    _test_field_name = "x_test_cd_partner"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _TestProductTemplate._build_model(cls.env.registry, cls.env.cr)
+        cls.env.registry.setup_models(cls.env.cr)
+        ctx = dict(cls.env.context, update_custom_fields=True)
+        cls.env.registry.init_models(cls.env.cr, ["product.template"], ctx)
+
+        cls.partner_a = cls.env["res.partner"].create({"name": "Partner A"})
+        cls.partner_default = cls.env["res.partner"].create({"name": "Partner Default"})
+        cls.tmpl = cls.env["product.template"].create(
+            {"name": "Tpl A", "no_create_variants": "yes"}
+        )
+        cls.tmpl.x_test_cd_partner = cls.partner_a
+
+    @classmethod
+    def tearDownClass(cls):
+        Template = cls.env["product.template"]
+        if cls._test_field_name in Template._fields:
+            Template._pop_field(cls._test_field_name)
+        cls.env.registry.setup_models(cls.env.cr)
+        super().tearDownClass()
+
+    def test_new_variant_keeps_existing_template_id_unwrapped(self):
+        new_variant = self.env["product.product"].new({"product_tmpl_id": self.tmpl.id})
+        self.assertEqual(new_variant.product_tmpl_id, self.tmpl)
+        self.assertEqual(new_variant.product_tmpl_id._ids, (self.tmpl.id,))
+
+    def test_new_variant_reads_template_company_dependent_value(self):
+        new_variant = self.env["product.product"].new({"product_tmpl_id": self.tmpl.id})
+        self.assertEqual(new_variant.x_test_cd_partner, self.partner_a)
+
+    def test_new_variant_reads_template_value_over_company_default(self):
+        self.env["ir.property"]._set_default(
+            self._test_field_name,
+            "product.template",
+            self.partner_default,
+        )
+        new_variant = self.env["product.product"].new({"product_tmpl_id": self.tmpl.id})
+        self.assertEqual(new_variant.x_test_cd_partner, self.partner_a)


### PR DESCRIPTION
This issue was noticed because some products were missing the values of _property_stock_production_ and _property_stock_inventory_ when there are default company properties that set their values.

The issue is reproduced like:

1. Create a new template. The company dependent fields should be filled in based on the default company properties (you can use for example _property_stock_production_ or _property_stock_inventory_).
2. From the product variants menu, create a new variant and assign it to the previously created template. The moment you assign it (even before saving the new variant) you will see that the company dependent fields get cleared out.
3. When saving the new variant, the cleared out values are written and the product ends up without the values set.

After investigating, the issue is affecting company-dependent fields that are managed at the product template level. It actually also affects other models that follow the __inherits_ structure. The reason why this happens is because:

1. For m2o fields related to __inherits_ structure (delegated) Odoo wraps the value as a newId if we are creating a new record: https://github.com/odoo/odoo/blob/c415f984c8ba4e636801fce752eb6fd2c0b8082e/odoo/fields.py#L3011. Odoo basically assumes that, if you are creating a new variant in the Form, you are also creating a new template.
2. When the template is assigned, the fields are then computed in https://github.com/odoo/odoo/blob/c415f984c8ba4e636801fce752eb6fd2c0b8082e/odoo/fields.py#L749 but the template is evaluated as a NewId so the results are False.

A patch on the _convert_to_cache_ method solves the issue and seems to be the right place to fix. Nonetheless, I am interested in other opinions on this.