### PR TITLE
[18.0][FIX] sale_variant_configurator: Show the attribute in the table (similar to v16)

### DIFF
--- a/sale_variant_configurator/views/sale_view.xml
+++ b/sale_variant_configurator/views/sale_view.xml
@@ -54,7 +54,7 @@
                     <list create="0" delete="0" editable="bottom">
                         <field name="owner_model" column_invisible="1" />
                         <field name="owner_id" column_invisible="1" />
-                        <field name="attribute_id" column_invisible="1" />
+                        <field name="attribute_id" force_save="1" />
                         <field
                             name="possible_value_ids"
                             widget="many2many_tags"


### PR DESCRIPTION
Show the attribute in the table (similar to v16)

**Before**
<img width="641" height="437" alt="antes" src="https://github.com/user-attachments/assets/f1efe806-64e5-48e6-91fc-1739c775e432" />

**After**
<img width="617" height="433" alt="despues" src="https://github.com/user-attachments/assets/01e2c594-d093-4c5a-9506-2d482ecc5823" />

Related to https://github.com/OCA/product-variant/commit/a2e44435d44fac07faad80bd2455d70f7e6e8bf4#diff-172eb8f7c140b0cd23a741a7fbea9e65639c6da45cf6b39f1da4773048271be8R57

Please @pedrobaeza can you review it?

@Tecnativa