### PR TITLE
[18.0][FIX] sale_variant_configurator: Option to create lines without a product_id

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -94,3 +94,14 @@ class SaleOrderLine(models.Model):
             line.tax_id = fiscal_position.map_tax(taxes) if fiscal_position else taxes
         self -= lines_with_template
         return super()._compute_tax_id()
+
+    @api.depends("product_tmpl_id")
+    def _compute_product_uom(self):
+        # Fill product_uom when no product is yet defined
+        lines_with_template = self.filtered(
+            lambda x: x.product_tmpl_id and not x.product_id
+        )
+        for line in lines_with_template:
+            line.product_uom = line.product_tmpl_id.uom_id
+        self -= lines_with_template
+        return super()._compute_product_uom()

--- a/sale_variant_configurator/views/sale_view.xml
+++ b/sale_variant_configurator/views/sale_view.xml
@@ -16,9 +16,25 @@
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/list//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="required"
+                >not display_type and not is_downpayment and not product_tmpl_id</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/list//field[@name='product_id']"
                 position="after"
             >
                 <field name="product_id_configurator_domain" column_invisible="1" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/list//field[@name='product_template_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="required"
+                >not display_type and not is_downpayment and not product_tmpl_id</attribute>
             </xpath>
             <xpath expr="//field[@name='order_line']" position="attributes">
                 <attribute name="options">{'reload_on_button': true}</attribute>
@@ -34,6 +50,9 @@
                 position="attributes"
             >
                 <attribute name="readonly">not product_updatable</attribute>
+                <attribute
+                    name="required"
+                >not display_type and not is_downpayment and not product_tmpl_id</attribute>
                 <attribute name="domain">product_id_configurator_domain</attribute>
             </xpath>
             <xpath


### PR DESCRIPTION
Backport from 16.0: https://github.com/OCA/product-variant/pull/395

Option to create lines without a `product_id`

Related to https://github.com/OCA/product-variant/pull/443/changes/631b5a4f6277d172b6b70f9bdd66b8e04c298e9b#r3243084247

**Before**
<img width="1394" height="852" alt="antes" src="https://github.com/user-attachments/assets/53ea516d-b5ac-46e1-b75f-105905c45c57" />

_After_
<img width="1394" height="862" alt="despues" src="https://github.com/user-attachments/assets/ecd03acd-3d01-4453-af87-e01c61a3c80d" />

Please @pedrobaeza and  @Andrii9090-tecnativa can you review it?

@Tecnativa TT61966