### PR TITLE
[19.0][FIX] sale_variant_configurator: Create variants only for lines with a product. Exclude display_type and down payment lines

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -50,7 +50,12 @@ class SaleOrderLine(models.Model):
         confirmed and a line is added.
         """
         for vals in vals_list:
-            if vals.get("order_id") and not vals.get("product_id"):
+            if (
+                vals.get("order_id")
+                and not vals.get("product_id")
+                and not vals.get("display_type")
+                and vals.get("product_tmpl_id")
+            ):
                 order = self.env["sale.order"].browse(vals["order_id"])
                 if order.state == "sale":
                     line = self.new(vals)


### PR DESCRIPTION
In some cases, this raises the following error:
```
prod odoo.sql_db: bad query: b'INSERT INTO "product_template" ("active", "create_date", "create_uid", "expense_policy", "intrastat_type", "invoice_policy", "is_accessory_cost", "is_storable", "list_price", "lot_sequence_id", "name", "no_create_variants", "product_properties", "property_stock_inventory", "property_stock_production", "purchase_method", "purchase_ok", "responsible_id", "sale_delay", "sale_ok", "sequence", "service_tracking", "service_type", "tracking", "type", "uom_id", "write_date", "write_uid") VALUES (true, \'2026-06-17T11:14:17.675070\'::timestamp, 1, \'no\', \'product\', \'order\', false, false, 1.0, 15, NULL, \'no\', NULL, NULL, NULL, \'receive\', true, NULL, 0, true, 1, \'no\', \'manual\', \'none\', \'consu\', 1, \'2026-06-17T11:14:17.675070\'::timestamp, 1) RETURNING "id"'
ERROR: null value in column "name" of relation "product_template" violates not-null constraint
DETAIL:  Failing row contains (185, 1, null, 1, null, null, 1, 1, consu, no, null, null, null, null, null, null, 1.0, null, null, t, t, t, null, null, null, 2026-06-17 11:14:17.67507, 2026-06-17 11:14:17.67507, null, null, 0, 15, none, null, null, null, null, null, null, f, receive, null, null, null, manual, no, order, null, null, null, null, null, null, no, null, product, f, null).
```
For example, this can be tested with `account_payment_sale` and `sale_variant_configurator` installed.

This PR adds a check to create variants only for sale order lines with a product, excluding lines with display_type != False and down payment lines.

@pedrobaeza @victoralmau can you review please?
@Tecnativa