### PR TITLE
[18.0][BP] sale_variant_configurator: Create variants only for lines with a product. Exclude display_type and down payment lines

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -56,7 +56,12 @@ class SaleOrderLine(models.Model):
         confirmed and a line is added.
         """
         for vals in vals_list:
-            if vals.get("order_id") and not vals.get("product_id"):
+            if (
+                vals.get("order_id")
+                and not vals.get("product_id")
+                and not vals.get("display_type")
+                and vals.get("product_tmpl_id")
+            ):
                 order = self.env["sale.order"].browse(vals["order_id"])
                 if order.state == "sale":
                     line = self.new(vals)


### PR DESCRIPTION
Backport #451 

@victoralmau @pedrobaeza ping
@Tecnativa 