### PR TITLE
[16.0][FIX] sale_variant_configurator: Create variants only for lines with a product. Exclude display_type and down payment lines

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -93,7 +93,8 @@ class SaleOrderLine(models.Model):
             if (
                 vals.get("order_id")
                 and not vals.get("product_id")
-                and not vals.get("is_downpayment")
+                and not vals.get("display_type")
+                and vals.get("product_tmpl_id")
             ):
                 order = self.env["sale.order"].browse(vals["order_id"])
                 if order.state == "sale":


### PR DESCRIPTION
Backport #451 

@pedrobaeza @victoralmau ping
@Tecnativa 