### PR TITLE
[16.0] [IMP] product_variant_default_code : add sequence to complete …

### DIFF
--- a/product_variant_default_code/__init__.py
+++ b/product_variant_default_code/__init__.py
@@ -1,2 +1,2 @@
-from . import models
 from .hooks import pre_init_hook
+from . import models

--- a/product_variant_default_code/models/config_settings.py
+++ b/product_variant_default_code/models/config_settings.py
@@ -23,3 +23,15 @@ class BaseConfiguration(models.TransientModel):
         default=False,
         config_parameter="product_variant_default_code.prefix_as_default_code",
     )
+
+    sequence_as_default_code = fields.Many2one(
+        string="Default sequence as default Reference",
+        comodel_name="ir.sequence",
+        config_parameter="product_variant_default_code.sequence_as_default_code",
+    )
+
+    use_sequence_per_product_tmp_as_default_code = fields.Boolean(
+        string="Use specific sequence par Product in Reference",
+        config_parameter="product_variant_default_code."
+        "use_sequence_per_product_tmp_as_default_code",
+    )

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -14,6 +14,8 @@ from string import Template
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
+SEQUENCE_PATTERN = "[SEQUENCE]"
+
 
 class ReferenceMask(Template):
     pattern = r"""\[(?:
@@ -33,11 +35,13 @@ def sanitize_reference_mask(product, mask):
     main_lang = product._guess_main_lang()
     tokens = extract_token(mask)
     attribute_names = set()
+    attribute_names.add(SEQUENCE_PATTERN[1:-1])
+    attribute_names.add("ID")
     for line in product.attribute_line_ids:
         attribute_names.add(line.attribute_id.with_context(lang=main_lang).name)
     if not tokens.issubset(attribute_names):
         raise UserError(
-            _('Found unrecognized attribute name in "Variant ' 'Reference Mask"')
+            _('Found unrecognized attribute name in "Variant Reference Mask"')
         )
 
 
@@ -73,11 +77,20 @@ class ProductTemplate(models.Model):
         ' `fancyA/l~r~l` (for variant with Color "Red" and Size "L") '
         ' `fancyA/x~y~x` (for variant with Color "Yellow" and Size "XL")'
         '\nNote: make sure characters "[,]" do not appear in your '
-        "attribute name",
+        "attribute name"
+        "Specific : set `%s` to add séquence number, [ID] for variant identifier"
+        % SEQUENCE_PATTERN,
     )
 
     variant_default_code_error = fields.Text(
         compute="_compute_variant_default_code_error"
+    )
+
+    code_sequence_id = fields.Many2one(
+        string="Default sequence as Reference",
+        comodel_name="ir.sequence",
+        default=False,
+        copy=False,
     )
 
     def is_automask(self):
@@ -196,6 +209,54 @@ class ProductTemplate(models.Model):
                 template.default_code = template.code_prefix
         return True
 
+    def _create_default_code_sequence(self):
+        current_pdt = self if len(self.ids) == 1 else False
+        params = self.env["ir.config_parameter"].sudo()
+        seq_model = self.env["ir.sequence"]
+        for_global = not bool(
+            params.get_param(
+                "product_variant_default_code.use_sequence_per_product_tmp_as_default_code"
+            )
+        )
+        seq = (
+            False
+            if not for_global
+            else seq_model.browse(
+                int(
+                    params.get_param(
+                        "product_variant_default_code.sequence_as_default_code"
+                    )
+                )
+            )
+        )
+        if for_global:
+            seq_name = _("Global Product Sequence")
+        else:
+            assert current_pdt
+            seq = self.code_sequence_id
+            seq_name = _("Product Sequence of %(name)s - %(identifier)s") % {
+                "name": current_pdt.name,
+                "identifier": current_pdt.id,
+            }
+        if not seq:
+            vals = {
+                "name": seq_name,
+                "code": "product_sequence_%s"
+                % (current_pdt.id if not for_global else 0),
+                "implementation": "no_gap",
+                "prefix": "",
+                "suffix": "",
+                "padding": 3,
+            }
+            seq = seq_model.create(vals)
+            if not for_global:
+                self.code_sequence_id = seq.id
+            else:
+                params.set_param(
+                    "product_variant_default_code.sequence_as_default_code", seq.id
+                )
+        return seq
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
@@ -237,6 +298,10 @@ class ProductProduct(models.Model):
             return None
         else:
             product_attrs = defaultdict(str)
+            product_attrs["ID"] = str(self.id)
+            if SEQUENCE_PATTERN in self.product_tmpl_id.reference_mask:
+                seq = self.product_tmpl_id._create_default_code_sequence()
+                product_attrs[SEQUENCE_PATTERN[1:-1]] = seq.next_by_id()
             reference_mask = ReferenceMask(self.product_tmpl_id.reference_mask)
             main_lang = self.product_tmpl_id._guess_main_lang()
             for attr in self.product_template_attribute_value_ids:

--- a/product_variant_default_code/tests/test_variant_default_code.py
+++ b/product_variant_default_code/tests/test_variant_default_code.py
@@ -6,6 +6,8 @@
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
+from ..models.product import SEQUENCE_PATTERN
+
 
 class TestVariantDefaultCode(TransactionCase):
     @classmethod
@@ -384,3 +386,134 @@ class TestVariantDefaultCode(TransactionCase):
                 ).name[0:2]
             )
             self.assertEqual(product.default_code, expected_code)
+
+    def test_19_mask_with_global_sequence(self):
+        self.env.user.groups_id |= self.group_default_code
+        template2 = self.env["product.template"].create(
+            {
+                "name": "Jacket for test 19",
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": self.attr1.id,
+                            "value_ids": [(6, 0, [self.attr1_1.id, self.attr1_2.id])],
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": self.attr2.id,
+                            "value_ids": [(6, 0, [self.attr2_1.id, self.attr2_2.id])],
+                        },
+                    ),
+                ],
+                "code_prefix": "pre/",
+                "reference_mask": "fix-[TColor]_%s" % SEQUENCE_PATTERN,
+            }
+        )
+        self.assertFalse(
+            self.env["ir.config_parameter"].get_param(
+                "product_variant_default_code.use_sequence_per_product_tmp_as_default_code",
+                False,
+            )
+        )
+        self.assertTrue(
+            self.env["ir.config_parameter"].get_param(
+                "product_variant_default_code.sequence_as_default_code", False
+            )
+        )
+        self.assertFalse(template2.code_sequence_id)
+        i = 0
+        list_expected_code = []
+        for product in template2.mapped("product_variant_ids"):
+            i = i + 1
+            expected_code = (
+                template2.code_prefix
+                + "fix-"
+                + product.product_template_attribute_value_ids.filtered(
+                    lambda x: x.product_attribute_value_id.attribute_id == self.attr2
+                ).name[0:2]
+                + "_"
+                + "%03d" % i
+            )
+            list_expected_code.append(expected_code)
+        self.assertEqual(
+            template2.mapped("product_variant_ids.default_code").sort(),
+            list_expected_code.sort(),
+        )
+
+    def test_20_mask_with_product_sequence(self):
+        self.env.user.groups_id |= self.group_default_code
+        self.env["ir.config_parameter"].set_param(
+            "product_variant_default_code.use_sequence_per_product_tmp_as_default_code",
+            True,
+        )
+        template2 = self.template1.copy()
+        template2.write(
+            {
+                "code_prefix": "pre/",
+                "reference_mask": "fix-[TColor]_%s" % SEQUENCE_PATTERN,
+            }
+        )
+        self.assertTrue(
+            self.env["ir.config_parameter"].get_param(
+                "product_variant_default_code.use_sequence_per_product_tmp_as_default_code",
+                False,
+            )
+        )
+        self.assertFalse(
+            self.env["ir.config_parameter"].get_param(
+                "product_variant_default_code.sequence_as_default_code", False
+            )
+        )
+        self.assertFalse(
+            self.env["ir.config_parameter"].get_param(
+                "product_variant_default_code.sequence_as_default_code", False
+            )
+        )
+        i = 0
+        list_expected_code = []
+        for product in template2.mapped("product_variant_ids"):
+            i = i + 1
+            expected_code = (
+                template2.code_prefix
+                + "fix-"
+                + product.product_template_attribute_value_ids.filtered(
+                    lambda x: x.product_attribute_value_id.attribute_id == self.attr2
+                ).name[0:2]
+                + "_"
+                + "%03d" % i
+            )
+            list_expected_code.append(expected_code)
+            product._compute_default_code()
+        self.assertEqual(
+            template2.mapped("product_variant_ids.default_code").sort(),
+            list_expected_code.sort(),
+        )
+        self.assertTrue(template2.code_sequence_id)
+
+    def test_21_mask_with_product_id(self):
+        self.env.user.groups_id |= self.group_default_code
+        template2 = self.template1.copy()
+        template2.write(
+            {
+                "reference_mask": "fix_[ID]",
+            }
+        )
+        list_expected_code = [
+            "fix_" + str(i) for i in template2.product_variant_ids.ids
+        ]
+        template2.product_variant_ids._compute_default_code()
+        self.assertEqual(
+            template2.mapped("product_variant_ids.default_code").sort(),
+            list_expected_code.sort(),
+        )
+        self.assertFalse(template2.code_sequence_id)
+        self.assertFalse(
+            self.env["ir.config_parameter"].get_param(
+                "product_variant_default_code.sequence_as_default_code", False
+            )
+        )

--- a/product_variant_default_code/views/config_settings_view.xml
+++ b/product_variant_default_code/views/config_settings_view.xml
@@ -30,6 +30,32 @@
                                 Defines the variant "Reference Prefix" as the default reference (default_code) of the variant.
                             </div>
                         </div>
+                        <div class="o_setting_left_pane">
+                            <field
+                                name="use_sequence_per_product_tmp_as_default_code"
+                            />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="use_sequence_per_product_tmp_as_default_code" />
+                            <div class="text-muted">
+                                Create the "Reference Sequence" per Product as the default for compute reference (default_code) of the variant.
+                            </div>
+                        </div>
+                        <div
+                            class="o_setting_right_pane"
+                            attrs="{'invisible': [('sequence_as_default_code', '=', True)]}"
+                        >
+                            <label for="sequence_as_default_code" />
+                            <div class="text-muted">
+                                Defines the "Reference Sequence" as the default for compute reference (default_code) of the variant.
+                            </div>
+                            <div
+                                class="content-group"
+                                attrs="{'invisible': [('sequence_as_default_code', '=', True)]}"
+                            >
+                                <field name="sequence_as_default_code" />
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -4,20 +4,29 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
-            <field name="default_code" position="after">
-                <field
-                    name="code_prefix"
-                    attrs="{'invisible':
-                          [('attribute_line_ids', '=', [])]}"
-                />
-                <field
-                    name="reference_mask"
-                    placeholder="[attribute3]-[attribute1]"
-                    attrs="{'invisible':
-                          [('attribute_line_ids', '=', [])]}"
-                    groups="product_variant_default_code.group_product_default_code_manual_mask"
-                />
-            </field>
+            <group name="group_standard_price" position="after">
+                <group
+                    name="group_product_variant_default_code_config"
+                    string="References configuration"
+                    colspan="2"
+                >
+                    <field
+                        name="code_prefix"
+                        attrs="{'invisible': [('attribute_line_ids', '=', [])]}"
+                    />
+                    <field
+                        name="reference_mask"
+                        placeholder="[attribute3]-[attribute1]"
+                        attrs="{'invisible': [('attribute_line_ids', '=', [])]}"
+                        groups="product_variant_default_code.group_product_default_code_manual_mask"
+                    />
+                    <field
+                        name="code_sequence_id"
+                        attrs="{'invisible': [('attribute_line_ids', '=', [])]}"
+                        groups="product_variant_default_code.group_product_default_code_manual_mask"
+                    />
+                </group>
+            </group>
             <xpath expr="//page/field[@name='attribute_line_ids']" position="before">
                     <field
                     name="variant_default_code_error"
@@ -32,9 +41,14 @@
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
-            <field name="default_code" position="before">
-                <field name="manual_code" />
-            </field>
+            <group name="group_standard_price" position="after">
+                <group
+                    name="group_product_variant_default_code_config"
+                    string="Reference configuration"
+                >
+                   <field name="manual_code" />
+                </group>
+            </group>
         </field>
     </record>
     <record id="product_variant_easy_edit_view" model="ir.ui.view">
@@ -42,7 +56,7 @@
         <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
         <field name="arch" type="xml">
             <field name="default_code" position="before">
-                <field name="manual_code" />
+               <field name="manual_code" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
…or replace patterns

When a product contains many attributes, it may be useful to simply use a prefix and a sequence.
This proposal consists of adding the possibility of defining two new patterns, one that will be replaced by a sequence value, global for specific to the product, and another to directly fill in the variant identifier.

to replace https://github.com/OCA/product-variant/pull/425
