### PR TITLE
[19.0][FIX] sale_variant_configurator: Add product_tmpl_id.uom_ids to allowed_uom_ids (sale.order.line)

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -104,3 +104,13 @@ class SaleOrderLine(models.Model):
             line.product_uom = line.product_tmpl_id.uom_id
         self -= lines_with_template
         return super()._compute_product_uom()
+
+    @api.depends("product_tmpl_id")
+    def _compute_allowed_uom_ids(self):
+        res = super()._compute_allowed_uom_ids()
+        for line in self:
+            if line.product_tmpl_id and not line.product_id:
+                line.allowed_uom_ids += (
+                    line.product_tmpl_id.uom_id | line.product_tmpl_id.uom_ids
+                )
+        return res


### PR DESCRIPTION
`sale.order.line.product_uom_id` has the domain` [("id", "in", allowed_uom_ids)]`. If `product_id` is not set, we can't select a UoM for this sale order line because `allowed_uom_ids` is empty.

Before fix
<img width="1463" height="1445" alt="image" src="https://github.com/user-attachments/assets/8f782a7d-2ab1-4742-a1bf-90b12344ddbc" />

After fix
<img width="1463" height="1445" alt="image" src="https://github.com/user-attachments/assets/bfde9034-db79-470e-8e5e-9274e269792e" />

@pedrobaeza can you review, please?
@Tecnativa