### PR TITLE
[14.0][FIX] product_variant_inactive: archive template with active_test

### DIFF
--- a/product_variant_inactive/models/product_template.py
+++ b/product_variant_inactive/models/product_template.py
@@ -37,7 +37,5 @@ class ProductTemplate(models.Model):
     @api.depends("product_variant_ids.active")
     def _compute_active(self):
         for template in self:
-            if not template.product_variant_ids.mapped("active"):
-                template.active = False
-            else:
-                template.active = True
+            variants = template.with_context(active_test=False).product_variant_ids
+            template.active = any(variants.mapped("active"))

--- a/product_variant_inactive/tests/test_product_variant_inactive.py
+++ b/product_variant_inactive/tests/test_product_variant_inactive.py
@@ -143,3 +143,13 @@ class TestProductProduct(SavepointCase):
         # check that variant is active and combination_deleted is False
         self.assertTrue(self.product_product_4c.active)
         self.assertFalse(self.product_product_4c.combination_deleted)
+
+    def test_compute_active_ignores_active_test(self):
+        template = self._create_template_with_variant()
+        template.with_context(active_test=False).product_variant_ids.write(
+            {"active": False}
+        )
+        template_no_test = template.with_context(active_test=False)
+        template_no_test.invalidate_cache(["active"])
+        template_no_test._compute_active()
+        self.assertFalse(template_no_test.active)


### PR DESCRIPTION
_compute_active tested the emptiness of the variant recordset instead of the active values. With active_test disabled,  roduct_variant_ids still returns the archived variants, so the template was set back to active.
This happens while archiving a template: the variants are archived through with_context(active_test=False), and a flush from that environment recomputes the field. Archiving then silently fails.
Use any() with an explicit active_test=False context.