### PR TITLE
[19.0][FIX] sale_variant_configurator: Apply the sale order partner’s language

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -65,11 +65,16 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def _get_product_description(self, template, product, product_attributes):
+        lang = self.order_id._get_lang()
+        if lang != self.env.lang:
+            if template:
+                template = template.with_context(lang=lang)
+            if product:
+                product = product.with_context(lang=lang)
         res = super()._get_product_description(
             template=template, product=product, product_attributes=product_attributes
         )
-        product = self.product_id.with_context(lang=self.order_partner_id.lang)
-        if product.description_sale:
+        if product and product.description_sale:
             res = (res or "") + "\n" + product.description_sale
         return res
 


### PR DESCRIPTION
Apply the sale order partner’s language when generating sale order line descriptions.
This ensures that sale order line descriptions are correctly translated.

@pedrobaeza can you review, please?

@Tecnativa
TT64253