### PR TITLE
[19.0][FIX] product_variant_configurator: translate

### DIFF
--- a/product_variant_configurator/models/product_configurator.py
+++ b/product_variant_configurator/models/product_configurator.py
@@ -14,6 +14,7 @@ _logger = logging.getLogger(__name__)
 class ProductConfigurator(models.AbstractModel):
     _name = "product.configurator"
     _description = "Product Configurator"
+    _partner_id_field = "partner_id"
 
     product_tmpl_id = fields.Many2one(
         string="Product Template",
@@ -152,15 +153,14 @@ class ProductConfigurator(models.AbstractModel):
         if not self.product_id:
             product_tmpl = self.product_tmpl_id
             values = self.product_attribute_ids.mapped("value_id")
-            if "partner_id" in self._fields:
+            if self._partner_id_field in self._fields:
+                partner = self[self._partner_id_field]
                 # If our model has a partner_id field, language is got from it
                 obj = self.env["product.attribute.value"].with_context(
-                    lang=self.partner_id.lang
+                    lang=partner.lang
                 )
                 values = obj.browse(self.product_attribute_ids.mapped("value_id").ids)
-                obj = self.env["product.template"].with_context(
-                    lang=self.partner_id.lang
-                )
+                obj = self.env["product.template"].with_context(lang=partner.lang)
                 product_tmpl = obj.browse(self.product_tmpl_id.id)
             if "name" in self._fields:
                 self.name = self._get_product_description(product_tmpl, False, values)
@@ -170,11 +170,12 @@ class ProductConfigurator(models.AbstractModel):
         self.ensure_one()
         if self.product_id:
             product = self.product_id
-            if "partner_id" in self._fields:
+            if self._partner_id_field in self._fields:
+                partner = self[self._partner_id_field]
                 # If our model has a partner_id field, language is got from it
                 product = (
                     self.env["product.product"]
-                    .with_context(lang=self.partner_id.lang)
+                    .with_context(lang=partner.lang)
                     .browse(self.product_id.id)
                 )
             if "name" in self._fields:

--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -68,8 +68,7 @@ class SaleOrderLine(models.Model):
         res = super()._get_product_description(
             template=template, product=product, product_attributes=product_attributes
         )
-        product = self.product_id.with_context(lang=self.order_partner_id.lang)
-        if product.description_sale:
+        if product and product.description_sale:
             res = (res or "") + "\n" + product.description_sale
         return res
 

--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -65,16 +65,11 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def _get_product_description(self, template, product, product_attributes):
-        lang = self.order_id._get_lang()
-        if lang != self.env.lang:
-            if template:
-                template = template.with_context(lang=lang)
-            if product:
-                product = product.with_context(lang=lang)
         res = super()._get_product_description(
             template=template, product=product, product_attributes=product_attributes
         )
-        if product and product.description_sale:
+        product = self.product_id.with_context(lang=self.order_partner_id.lang)
+        if product.description_sale:
             res = (res or "") + "\n" + product.description_sale
         return res
 


### PR DESCRIPTION
Revert commit #462 and added the changes that were lost since the [v16](https://github.com/OCA/product-variant/commit/2351a7b22da9b22de461e71cbc004493e648a5f4#diff-da880cc7befc12d224f5853cd6b452dbbc02c1074d03c2019391c7630f1bb4aeR154) migration and are missing in the [v17](https://github.com/OCA/product-variant/commit/516d71ae291d182d35cad4db951f81233a569237) migration. These changes are essential to use the product name, variant names, and description in the partner’s language context.

`sale.order.line` doesn't have a `partner_id` field; it uses [order_partner_id](https://github.com/odoo/odoo/blob/19.0/addons/sale/models/sale_order_line.py#L48). Therefore, without these changes, the partner’s language context is not applied. 
`SaleOrderLine` has [_partner_id_field](https://github.com/OCA/product-variant/blob/19.0/sale_variant_configurator/models/sale_order.py#L25) defined.

@pedrobaeza @victoralmau can you review?

TT64264
@Tecnativa