### PR TITLE
[19.0][FIX] product_variant_configurator: Create product with sudo

### DIFF
--- a/product_variant_configurator/models/product_configurator.py
+++ b/product_variant_configurator/models/product_configurator.py
@@ -302,7 +302,9 @@ class ProductConfigurator(models.AbstractModel):
                     prod_attr_val=product_attribute_value: v.product_attribute_value_id  # noqa
                     == prod_attr_val
                 )
-            product = product_obj.create(
+            # Create the product with sudo for not requiring the permission for creating
+            # products to those users confirming the SO/PO
+            product = product_obj.sudo().create(
                 {
                     "name": self.product_tmpl_id.name,
                     "product_tmpl_id": self.product_tmpl_id.id,


### PR DESCRIPTION
The user confirming the sales/purchase may not have permission to create products, but it's logical to not require such permission in these flows, as this is only creating a variant of an existing template, so let's make it with sudo.

@Tecnativa TT64287