### PR TITLE
[19.0][FIX] sale_variant_configurator: Unit of measure in product templates

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -94,15 +94,15 @@ class SaleOrderLine(models.Model):
         return super()._compute_tax_id()
 
     @api.depends("product_tmpl_id")
-    def _compute_product_uom(self):
-        # Fill product_uom when no product is yet defined
+    def _compute_product_uom_id(self):
+        # Fill product_uom_id when no product is yet defined
         lines_with_template = self.filtered(
             lambda x: x.product_tmpl_id and not x.product_id
         )
         for line in lines_with_template:
-            line.product_uom = line.product_tmpl_id.uom_id
+            line.product_uom_id = line.product_tmpl_id.uom_id
         self -= lines_with_template
-        return super()._compute_product_uom()
+        return super()._compute_product_uom_id()
 
     @api.depends("product_tmpl_id")
     def _compute_allowed_uom_ids(self):


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/product-variant/pull/395

Steps to reproduce the error:
- Go to Sales > Configuration and activate 'Units of Measure'.
- Go to a quotation and add a line indicating a Product Template with several attributes (Conference Chair for example).
- You must be able to select a unit of measure + the unit of measure is set automatically.

Other versions (v13 for example) use another technique https://github.com/OCA/product-variant/blob/2922137d2de670010200fa0cb7cdf1469bffafbe/sale_variant_configurator/models/sale_order.py#L69

Please @Andrii9090-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT55223