### PR TITLE
[18.0][FIX] sale_variant_configurator: Do not create products for downpayments

### DIFF
--- a/sale_variant_configurator/models/sale_order.py
+++ b/sale_variant_configurator/models/sale_order.py
@@ -35,7 +35,7 @@ class SaleOrderLine(models.Model):
     _sql_constraints = [
         (
             "accountable_required_fields",
-            "CHECK(display_type IS NOT NULL OR "
+            "CHECK(display_type IS NOT NULL OR is_downpayment OR"
             "((product_id IS NOT NULL OR product_tmpl_id IS NOT NULL) AND "
             "product_uom IS NOT NULL))",
             "Missing required fields on accountable sale order line.",
@@ -61,6 +61,7 @@ class SaleOrderLine(models.Model):
                 and not vals.get("product_id")
                 and not vals.get("display_type")
                 and vals.get("product_tmpl_id")
+                and not vals.get("is_downpayment")
             ):
                 order = self.env["sale.order"].browse(vals["order_id"])
                 if order.state == "sale":


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/product-variant/pull/398

Do not create products for downpayments

**Before**:
![antes](https://github.com/user-attachments/assets/5a78c984-257a-4e25-b88e-38eb19bb6193)

**After**:
![despues](https://github.com/user-attachments/assets/58ebcafa-3c65-4f0d-ab4c-097d437ab07c)

Please @Andrii9090-tecnativa and @pedrobaeza can you review it?

@Tecnativa